### PR TITLE
Bump minimum acorn version to @7.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "out"
   ],
   "dependencies": {
-    "acorn": "^7.1.1",
+    "acorn": "^7.4.1",
     "acorn-class-fields": "^0.3.2",
     "acorn-export-ns-from": "^0.1.0",
     "acorn-import-meta": "^1.1.0",


### PR DESCRIPTION
This includes support for optional chaining so should fix those errors in analysis.