### PR TITLE
feat: resolve "imports" and "exports" wildcards

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,15 +57,15 @@ const { fileList } = await nodeFileTrace(files, {
 
 By default `processCwd` is the same as `base`.
 
-#### Exports
+#### Exports & Imports
 
-By default tracing of the [Node.js "exports" field](https://nodejs.org/dist/latest-v14.x/docs/api/esm.html#esm_package_entry_points) is supported, with the `"node"`, `"require"`, `"import"` and `"default"` conditions traced as defined.
+By default tracing of the [Node.js "exports" and "imports" fields](https://nodejs.org/dist/latest-v14.x/docs/api/esm.html#esm_package_entry_points) is supported, with the `"node"`, `"require"`, `"import"` and `"default"` conditions traced as defined.
 
-Alternatively the explicit list of exports can be provided:
+Alternatively the explicit list of conditions can be provided:
 
 ```js
 const { fileList } = await nodeFileTrace(files, {
-  exports: ['node', 'production']
+  conditions: ['node', 'production']
 });
 ```
 

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -71,8 +71,8 @@ export class Job {
   constructor ({
     base = process.cwd(),
     processCwd,
-    exports = ['node'],
-    conditions = exports,
+    exports,
+    conditions = exports || ['node'],
     exportsOnly = false,
     paths = {},
     ignore,

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -51,7 +51,7 @@ export class Job {
   public ts: boolean;
   public base: string;
   public cwd: string;
-  public exports: string[];
+  public conditions: string[];
   public exportsOnly: boolean;
   public paths: Record<string, string>;
   public ignoreFn: (path: string, parent?: string) => boolean;
@@ -72,6 +72,7 @@ export class Job {
     base = process.cwd(),
     processCwd,
     exports = ['node'],
+    conditions = exports,
     exportsOnly = false,
     paths = {},
     ignore,
@@ -106,7 +107,7 @@ export class Job {
     }
     this.base = base;
     this.cwd = resolve(processCwd || base);
-    this.exports = exports;
+    this.conditions = conditions;
     this.exportsOnly = exportsOnly;
     const resolvedPaths: Record<string, string> = {};
     for (const path of Object.keys(paths)) {

--- a/src/resolve-dependency.ts
+++ b/src/resolve-dependency.ts
@@ -145,7 +145,7 @@ function resolveExportsImports (pkgPath: string, obj: PackageTarget, subpath: st
     if (typeof target === 'string' && target.startsWith('./'))
       return pkgPath + target.slice(1);
   }
-  for (const match of Object.keys(matchObj).sort((a, b) => a.length > b.length ? -1 : 1)) {
+  for (const match of Object.keys(matchObj).sort((a, b) => b.length - a.length)) {
     if (match.endsWith('*') && subpath.startsWith(match.slice(0, -1))) {
       const target = getExportsTarget(matchObj[match], job.conditions, cjsResolve);
       if (typeof target === 'string' && target.startsWith('./'))

--- a/src/resolve-dependency.ts
+++ b/src/resolve-dependency.ts
@@ -10,6 +10,9 @@ export default function resolveDependency (specifier: string, parent: string, jo
     const trailingSlash = specifier.endsWith('/');
     resolved = resolvePath(resolve(parent, '..', specifier) + (trailingSlash ? '/' : ''), parent, job);
   }
+  else if (specifier[0] === '#') {
+    resolved = packageImportsResolve(specifier, parent, job, cjsResolve);
+  }
   else {
     resolved = resolvePackage(specifier, parent, job, cjsResolve);
   }
@@ -74,12 +77,13 @@ function getPkgName (name: string) {
   return segments.length ? segments[0] : null;
 }
 
-type Exports = string | string[] | { [key: string]: string } | null | undefined;
+type PackageTarget = string | PackageTarget[] | { [key: string]: PackageTarget } | null;
 
 interface PkgCfg {
   name: string | undefined;
   main: string | undefined;
-  exports: Exports;
+  exports: PackageTarget;
+  imports: { [key: string]: PackageTarget };
 }
 
 function getPkgCfg (pkgPath: string, job: Job): PkgCfg | undefined {
@@ -93,7 +97,7 @@ function getPkgCfg (pkgPath: string, job: Job): PkgCfg | undefined {
   return undefined;
 }
 
-function getExportsTarget(exports: string | string[] | { [key: string]: string } | null, conditions: string[], cjsResolve: boolean): string | null | undefined {
+function getExportsTarget(exports: PackageTarget, conditions: string[], cjsResolve: boolean): string | null | undefined {
   if (typeof exports === 'string') {
     return exports;
   }
@@ -123,30 +127,63 @@ function getExportsTarget(exports: string | string[] | { [key: string]: string }
   return undefined;
 }
 
-function resolveExportsTarget (pkgPath: string, exp: string | string[] | { [key: string]: string }, subpath: string, job: Job, cjsResolve: boolean): string | undefined {
-  let exports: { [key: string]: string | string[] | { [key: string]: string } };
-  if (typeof exp === 'string' ||
-      typeof exp === 'object' && !Array.isArray(exp) && Object.keys(exp).length && Object.keys(exp)[0][0] !== '.') {
-    exports = { '.' : exp };
+function resolveExportsImports (pkgPath: string, obj: PackageTarget, subpath: string, job: Job, isImports: boolean, cjsResolve: boolean): string | undefined {
+  let matchObj: { [key: string]: PackageTarget };
+  if (isImports) {
+    if (!(typeof obj === 'object' && !Array.isArray(obj) && obj !== null))
+      return undefined;
+    matchObj = obj;
+  } else if (typeof obj === 'string' || Array.isArray(obj) || obj === null ||
+      typeof obj === 'object' && Object.keys(obj).length && Object.keys(obj)[0][0] !== '.') {
+    matchObj = { '.' : obj };
   } else {
-    exports = exp;
+    matchObj = obj;
   }
   
-  if (subpath in exports) {
-    const target = getExportsTarget(exports[subpath], job.exports, cjsResolve);
+  if (subpath in matchObj) {
+    const target = getExportsTarget(matchObj[subpath], job.conditions, cjsResolve);
     if (typeof target === 'string' && target.startsWith('./'))
       return pkgPath + target.slice(1);
   }
-  for (const match of Object.keys(exports)) {
+  for (const match of Object.keys(matchObj).sort((a, b) => a.length > b.length ? -1 : 1)) {
+    if (match.endsWith('*') && subpath.startsWith(match.slice(0, -1))) {
+      const target = getExportsTarget(matchObj[match], job.conditions, cjsResolve);
+      if (typeof target === 'string' && target.startsWith('./'))
+        return pkgPath + target.slice(1).replace(/\*/g, subpath.slice(match.length - 1));
+    }
     if (!match.endsWith('/'))
       continue;
     if (subpath.startsWith(match)) {
-      const target = getExportsTarget(exports[match], job.exports, cjsResolve);
+      const target = getExportsTarget(matchObj[match], job.conditions, cjsResolve);
       if (typeof target === 'string' && target.endsWith('/') && target.startsWith('./'))
-        return pkgPath + match.slice(1) + subpath.slice(match.length);
+        return pkgPath + target.slice(1) + subpath.slice(match.length);
     }
   }
   return undefined;
+}
+
+function packageImportsResolve (name: string, parent: string, job: Job, cjsResolve: boolean): string {
+  if (name !== '#' && !name.startsWith('#/') && job.conditions) {
+    const pjsonBoundary = job.getPjsonBoundary(parent);
+    if (pjsonBoundary) {
+      const pkgCfg = getPkgCfg(pjsonBoundary, job);
+      const { imports: pkgImports } = pkgCfg || {};
+      if (pkgCfg && pkgImports !== null && pkgImports !== undefined) {
+        let importsResolved = resolveExportsImports(pjsonBoundary, pkgImports, name, job, true, cjsResolve);
+        if (importsResolved) {
+          if (cjsResolve)
+            importsResolved = resolveFile(importsResolved, parent, job) || resolveDir(importsResolved, parent, job);
+          else if (!job.isFile(importsResolved))
+            throw new NotFoundError(importsResolved, parent);
+          if (importsResolved) {
+            job.emitFile(pjsonBoundary + sep + 'package.json', 'resolve', parent);
+            return importsResolved;
+          }
+        }
+      }
+    }
+  }
+  throw new NotFoundError(name, parent);
 }
 
 function resolvePackage (name: string, parent: string, job: Job, cjsResolve: boolean): string | string [] {
@@ -157,13 +194,13 @@ function resolvePackage (name: string, parent: string, job: Job, cjsResolve: boo
   
   // package own name resolution
   let selfResolved: string | undefined;
-  if (job.exports) {
+  if (job.conditions) {
     const pjsonBoundary = job.getPjsonBoundary(parent);
     if (pjsonBoundary) {
       const pkgCfg = getPkgCfg(pjsonBoundary, job);
       const { exports: pkgExports } = pkgCfg || {};
       if (pkgCfg && pkgCfg.name && pkgExports !== null && pkgExports !== undefined) {
-        selfResolved = resolveExportsTarget(pjsonBoundary, pkgExports, '.' + name.slice(pkgName.length), job, cjsResolve);
+        selfResolved = resolveExportsImports(pjsonBoundary, pkgExports, '.' + name.slice(pkgName.length), job, false, cjsResolve);
         if (selfResolved) {
           if (cjsResolve)
             selfResolved = resolveFile(selfResolved, parent, job) || resolveDir(selfResolved, parent, job);
@@ -185,11 +222,11 @@ function resolvePackage (name: string, parent: string, job: Job, cjsResolve: boo
     if (!stat || !stat.isDirectory()) continue;
     const pkgCfg = getPkgCfg(nodeModulesDir + sep + pkgName, job);
     const { exports: pkgExports } = pkgCfg || {};
-    if (job.exports && pkgExports !== undefined && pkgExports !== null && !selfResolved) {
+    if (job.conditions && pkgExports !== undefined && pkgExports !== null && !selfResolved) {
       let legacyResolved;
       if (!job.exportsOnly)
         legacyResolved = resolveFile(nodeModulesDir + sep + name, parent, job) || resolveDir(nodeModulesDir + sep + name, parent, job);
-      let resolved = resolveExportsTarget(nodeModulesDir + sep + pkgName, pkgExports, '.' + name.slice(pkgName.length), job, cjsResolve);
+      let resolved = resolveExportsImports(nodeModulesDir + sep + pkgName, pkgExports, '.' + name.slice(pkgName.length), job, false, cjsResolve);
       if (resolved) {
         if (cjsResolve)
           resolved = resolveFile(resolved, parent, job) || resolveDir(resolved, parent, job);

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export interface NodeFileTraceOptions {
   base?: string;
   processCwd?: string;
   exports?: string[];
+  conditions?: string[];
   exportsOnly?: boolean;
   ignore?: string | string[] | ((path: string) => boolean);
   analysis?: boolean | {

--- a/test/unit/exports-nomodule/input.js
+++ b/test/unit/exports-nomodule/input.js
@@ -1,0 +1,2 @@
+import { x } from 'x';
+console.log(x);

--- a/test/unit/exports-nomodule/no.js
+++ b/test/unit/exports-nomodule/no.js
@@ -1,0 +1,1 @@
+export var y = 'y';

--- a/test/unit/exports-nomodule/node.js
+++ b/test/unit/exports-nomodule/node.js
@@ -1,0 +1,1 @@
+export var x = 'x';

--- a/test/unit/exports-nomodule/output.js
+++ b/test/unit/exports-nomodule/output.js
@@ -1,0 +1,5 @@
+[
+  "test/unit/exports-nomodule/input.js",
+  "test/unit/exports-nomodule/node.js",
+  "test/unit/exports-nomodule/package.json"
+]

--- a/test/unit/exports-nomodule/package.json
+++ b/test/unit/exports-nomodule/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "x",
+  "type": "module",
+  "exports": {
+    ".": {
+      "module": "./no.js",
+      "default": {
+        "node": "./node.js"
+      }
+    }
+  }
+}

--- a/test/unit/exports-wildcard/input.js
+++ b/test/unit/exports-wildcard/input.js
@@ -1,0 +1,2 @@
+import { y } from 'y/no';
+console.log(y);

--- a/test/unit/exports-wildcard/no.js
+++ b/test/unit/exports-wildcard/no.js
@@ -1,0 +1,1 @@
+export var x = 'x';

--- a/test/unit/exports-wildcard/node.js
+++ b/test/unit/exports-wildcard/node.js
@@ -1,0 +1,1 @@
+export var y = 'y';

--- a/test/unit/exports-wildcard/output.js
+++ b/test/unit/exports-wildcard/output.js
@@ -1,0 +1,5 @@
+[
+  "test/unit/exports-wildcard/input.js",
+  "test/unit/exports-wildcard/node.js",
+  "test/unit/exports-wildcard/package.json"
+]

--- a/test/unit/exports-wildcard/package.json
+++ b/test/unit/exports-wildcard/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "y",
+  "type": "module",
+  "exports": {
+    "./*": {
+      "module": "./*.js",
+      "default": {
+        "node": "./*de.js"
+      }
+    }
+  }
+}

--- a/test/unit/imports/input.js
+++ b/test/unit/imports/input.js
@@ -1,0 +1,2 @@
+import { x } from '#x';
+console.log(x);

--- a/test/unit/imports/no.js
+++ b/test/unit/imports/no.js
@@ -1,0 +1,1 @@
+export var y = 'y';

--- a/test/unit/imports/node.js
+++ b/test/unit/imports/node.js
@@ -1,0 +1,1 @@
+export var x = 'x';

--- a/test/unit/imports/output.js
+++ b/test/unit/imports/output.js
@@ -1,0 +1,5 @@
+[
+  "test/unit/imports/input.js",
+  "test/unit/imports/node.js",
+  "test/unit/imports/package.json"
+]

--- a/test/unit/imports/package.json
+++ b/test/unit/imports/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "x",
+  "type": "module",
+  "imports": {
+    "#x": {
+      "module": "./no.js",
+      "default": {
+        "node": "./node.js"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This updates the resolver to the latest Node.js resolver handling per the modules stability with "imports" support and "exports" wildcards support.

In the API, the `"exports"` option has been renamed to `"conditions"` as it applies to both "imports" and "exports", but backwards compatibility is provided for the former exports option so this is non-breaking.