### PR TITLE
Support import.meta.url asset emission

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/bindings": "^1.3.0",
     "@types/glob": "^7.1.2",
     "@types/micromatch": "^4.0.1",
-    "@types/node": "^14.0.14",
+    "@types/node": "^14.14.37",
     "analytics-node": "^3.4.0-beta.1",
     "apollo-server-express": "^2.14.2",
     "argon2": "^0.24.0",

--- a/src/utils/static-eval.ts
+++ b/src/utils/static-eval.ts
@@ -316,6 +316,68 @@ const visitors: Record<string, (this: State, node: Node, walk: Walk) => Evaluate
     }
     return undefined;
   },
+  'MetaProperty': function MetaProperty(this: State, node: Node) {
+    if (node.meta.name === 'import' && node.property.name === 'meta')
+      return { value: this.vars['import.meta'] };
+    return undefined;
+  },
+  'NewExpression': function NewExpression(this: State, node: Node, walk: Walk) {
+    // new URL('./local', parent)
+    const cls = walk(node.callee);
+    if (cls && 'value' in cls && cls.value === URL && node.arguments.length) {
+      const arg = walk(node.arguments[0]);
+      if (!arg)
+        return undefined;
+      let parent = null;
+      if (node.arguments[1]) {
+        parent = walk(node.arguments[1]);
+        if (!parent || !('value' in parent))
+          return undefined;
+      }
+      if ('value' in arg) {
+        if (parent) {
+          try {
+            return { value: new URL(arg.value, parent.value) };
+          }
+          catch {
+            return undefined;
+          }
+        }
+        try {
+          return { value: new URL(arg.value) };
+        }
+        catch {
+          return undefined;
+        }
+      }
+      else {
+        const test = arg.test;
+        if (parent) {
+          try {
+            return {
+              test,
+              then: new URL(arg.then, parent.value),
+              else: new URL(arg.else, parent.value)
+            };
+          }
+          catch {
+            return undefined;
+          }
+        }
+        try {
+          return {
+            test,
+            then: new URL(arg.then),
+            else: new URL(arg.else)
+          };
+        }
+        catch {
+          return undefined;
+        }
+      }
+    }
+    return undefined;
+  },
   'ObjectExpression': function ObjectExpression(this: State, node: Node, walk: Walk) {
     const obj: any = {};
     for (let i = 0; i < node.properties.length; i++) {

--- a/src/utils/static-eval.ts
+++ b/src/utils/static-eval.ts
@@ -1,5 +1,6 @@
 import { Node } from 'estree-walker';
 import { EvaluatedValue, StaticValue, ConditionalValue } from '../types';
+import { URL } from 'url';
 type Walk = (node: Node) => EvaluatedValue;
 type State = { computeBranches: boolean, vars: Record<string, any> };
 

--- a/test/unit/import-meta-bad-url/asset1.txt
+++ b/test/unit/import-meta-bad-url/asset1.txt
@@ -1,0 +1,1 @@
+hello world

--- a/test/unit/import-meta-bad-url/asset2.txt
+++ b/test/unit/import-meta-bad-url/asset2.txt
@@ -1,0 +1,1 @@
+hello world

--- a/test/unit/import-meta-bad-url/input.js
+++ b/test/unit/import-meta-bad-url/input.js
@@ -1,0 +1,11 @@
+import { readFileSync } from 'fs';
+
+console.log(readFileSync(new URL(unknown ? './asset1.txt' : './asset2.txt', 'not-a-url')));
+console.log(readFileSync(new URL(unknown ? 'a--b' : './asset2.txt')));
+console.log(readFileSync(new URL(unknown ? './asset1.txt' : 'a--b')));
+console.log(readFileSync(new URL('file:///none')));
+console.log(readFileSync(new URL('--')));
+console.log(readFileSync(new URL('--', '--')));
+console.log(readFileSync(new URL()));
+console.log(readFileSync(new URL('./test', unknown)));
+console.log(readFileSync(new URL(unknown)));

--- a/test/unit/import-meta-bad-url/output.js
+++ b/test/unit/import-meta-bad-url/output.js
@@ -1,0 +1,4 @@
+[
+  "package.json",
+  "test/unit/import-meta-bad-url/input.js"
+]

--- a/test/unit/import-meta-tpl-cnd/asset1.txt
+++ b/test/unit/import-meta-tpl-cnd/asset1.txt
@@ -1,0 +1,1 @@
+hello world

--- a/test/unit/import-meta-tpl-cnd/asset2.txt
+++ b/test/unit/import-meta-tpl-cnd/asset2.txt
@@ -1,0 +1,1 @@
+hello world

--- a/test/unit/import-meta-tpl-cnd/input.js
+++ b/test/unit/import-meta-tpl-cnd/input.js
@@ -1,0 +1,4 @@
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+console.log(readFileSync(fileURLToPath(`${import.meta.url}/../${unknown ? 'asset1.txt' : 'asset2.txt'}`)).toString());

--- a/test/unit/import-meta-tpl-cnd/output.js
+++ b/test/unit/import-meta-tpl-cnd/output.js
@@ -1,0 +1,6 @@
+[
+  "package.json",
+  "test/unit/import-meta-tpl-cnd/asset1.txt",
+  "test/unit/import-meta-tpl-cnd/asset2.txt",
+  "test/unit/import-meta-tpl-cnd/input.js"
+]

--- a/test/unit/import-meta-url/asset.txt
+++ b/test/unit/import-meta-url/asset.txt
@@ -1,0 +1,1 @@
+hello world

--- a/test/unit/import-meta-url/input.js
+++ b/test/unit/import-meta-url/input.js
@@ -1,0 +1,2 @@
+import fs from 'fs';
+console.log(fs.readFileSync(new URL('./asset.txt', import.meta.url)));

--- a/test/unit/import-meta-url/output.js
+++ b/test/unit/import-meta-url/output.js
@@ -1,0 +1,5 @@
+[
+  "package.json",
+  "test/unit/import-meta-url/asset.txt",
+  "test/unit/import-meta-url/input.js"
+]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
-    "lib": ["esnext"],
+    "lib": ["esnext", "DOM"],
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmitOnError": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
-    "lib": ["esnext", "DOM"],
+    "lib": ["esnext"],
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmitOnError": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1890,7 +1890,7 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@>=12.12.47", "@types/node@^14.0.14", "@types/node@^14.14.28":
+"@types/node@*", "@types/node@>=12.12.47", "@types/node@^14.14.28":
   version "14.14.35"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.35.tgz#42c953a4e2b18ab931f72477e7012172f4ffa313"
   integrity sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
@@ -1904,6 +1904,11 @@
   version "13.13.47"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.47.tgz#6eca42c3462821309b26edbc2eff0db1e37ab9bc"
   integrity sha512-R6851wTjN1YJza8ZIeX6puNBSi/ZULHVh4WVleA7q256l+cP2EtXnKbO455fTs2ytQk3dL9qkU+Wh8l/uROdKg==
+
+"@types/node@^14.14.37":
+  version "14.14.37"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.37.tgz#a3dd8da4eb84a996c36e331df98d82abd76b516e"
+  integrity sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==
 
 "@types/node@^8.10.59":
   version "8.10.66"


### PR DESCRIPTION
This adds support for `import.meta.url` based asset emission in NFT.

The approach is to treat `import.meta.url` as an asset trigger, which then emits path references just like `__filename` and `__dirname`.

Support is included for `new URL('./path', import.meta.url)` patterns as well with global analysis of the `URL` object.

`pathToFileURL` and `fileURLToPath` work out without custom handling since they are effectively irrelevant in the asset emission approach used here.

Quite advanced patterns are supported, eg a test is included for the following case:

```js
import { readFileSync } from 'fs';
import { fileURLToPath } from 'url';

console.log(readFileSync(
  fileURLToPath(`${import.meta.url}/../${unknownCondition ? 'asset1.txt' : 'asset2.txt'}`)
).toString()); 
```

emitting both `asset1.txt` and `asset2.txt` as possible references.