### PR TITLE
fix: add missing @types/estree

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@tensorflow/tfjs-node": "^3.6.1",
     "@tpluscode/sparql-builder": "^0.3.12",
     "@types/bindings": "^1.3.0",
+    "@types/estree": "^0.0.47",
     "@types/glob": "^7.1.2",
     "@types/micromatch": "^4.0.1",
     "@types/node": "^14.14.37",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { Job } from './node-file-trace';
+import { Node as TreeNode } from 'estree';
 
 export interface Stats {
   isFile(): boolean;
@@ -78,3 +79,5 @@ export interface ConditionalValue {
 }
 
 export type EvaluatedValue = StaticValue | ConditionalValue | undefined;
+
+export type Ast = { body: TreeNode[] };

--- a/src/utils/wrappers.ts
+++ b/src/utils/wrappers.ts
@@ -1,13 +1,38 @@
-import { walk, Node } from 'estree-walker';
+import { walk } from 'estree-walker';
+import { Ast } from '../types';
+import { SimpleCallExpression, Node, Statement, Literal } from 'estree';
 
 function isUndefinedOrVoid (node: Node) {
   return node.type === 'Identifier' && node.name === 'undefined' || node.type === 'UnaryExpression' && node.operator === 'void' && node.argument.type === 'Literal' && node.argument.value === 0;
 }
+function getLastReturnCalleeArgumentProps(statements: Statement[]) {
+  const last = statements[statements.length - 1];
+
+  if (last.type === 'ReturnStatement' &&
+  last.argument &&
+  last.argument.type === 'CallExpression' &&
+  last.argument.callee.type === 'CallExpression' &&
+  last.argument.arguments.length &&
+  last.argument.arguments.every(arg => arg && arg.type === 'Literal' && typeof arg.value === 'number') &&
+  (
+    last.argument.callee.callee.type === 'FunctionExpression' ||
+    last.argument.callee.callee.type === 'CallExpression' &&
+    last.argument.callee.callee.callee.type === 'FunctionExpression' &&
+    last.argument.callee.callee.arguments.length === 0
+  ) &&
+  // (dont go deeper into browserify loader internals than this)
+  last.argument.callee.arguments.length === 3 &&
+  last.argument.callee.arguments[0].type === 'ObjectExpression' &&
+  last.argument.callee.arguments[1].type === 'ObjectExpression' &&
+  last.argument.callee.arguments[2].type === 'ArrayExpression') {
+    return last.argument.callee.arguments[0].properties;
+  }
+}
 
 // Wrapper detection pretransforms to enable static analysis
-export function handleWrappers(ast: Node) {
+export function handleWrappers(ast: Ast) {
   // UglifyJS will convert function wrappers into !function(){}
-  let wrapper;
+  let wrapper: SimpleCallExpression | undefined;
   if (ast.body.length === 1 &&
       ast.body[0].type === 'ExpressionStatement' &&
       ast.body[0].expression.type === 'UnaryExpression' &&
@@ -48,6 +73,7 @@ export function handleWrappers(ast: Node) {
         wrapper.arguments[0].test.left.operator === '===' &&
         wrapper.arguments[0].test.left.left.type === 'UnaryExpression' &&
         wrapper.arguments[0].test.left.left.operator === 'typeof' &&
+        'name' in wrapper.arguments[0].test.left.left.argument &&
         wrapper.arguments[0].test.left.left.argument.name === 'define' &&
         wrapper.arguments[0].test.left.right.type === 'Literal' &&
         wrapper.arguments[0].test.left.right.value === 'function' &&
@@ -71,6 +97,9 @@ export function handleWrappers(ast: Node) {
         wrapper.arguments[0].alternate.body.body[0].expression.right.type === 'CallExpression' &&
         wrapper.arguments[0].alternate.body.body[0].expression.right.callee.type === 'Identifier' &&
         wrapper.arguments[0].alternate.body.body[0].expression.right.callee.name === wrapper.arguments[0].alternate.params[0].name &&
+        'body' in wrapper.callee &&
+        'body' in wrapper.callee.body &&
+        Array.isArray(wrapper.callee.body.body) &&
         wrapper.arguments[0].alternate.body.body[0].expression.right.arguments.length === 1 &&
         wrapper.arguments[0].alternate.body.body[0].expression.right.arguments[0].type === 'Identifier' &&
         wrapper.arguments[0].alternate.body.body[0].expression.right.arguments[0].name === 'require') {
@@ -91,8 +120,12 @@ export function handleWrappers(ast: Node) {
           body[0].expression.arguments[0].params.length === 1 &&
           body[0].expression.arguments[0].params[0].type === 'Identifier' &&
           body[0].expression.arguments[0].params[0].name === 'require') {
-        delete body[0].expression.arguments[0].scope.declarations.require;
-        body[0].expression.arguments[0].params = [];
+        const arg = body[0].expression.arguments[0];
+        arg.params = [];
+        try {  
+          // @ts-ignore If it doesn't exist thats ok
+          delete arg.scope.declarations.require;
+        } catch (e) {}
       }
     }
     // Browserify-style wrapper
@@ -117,36 +150,22 @@ export function handleWrappers(ast: Node) {
             wrapper.arguments[0].body.body.length === 2 &&
             wrapper.arguments[0].body.body[0].type === 'VariableDeclaration' &&
             wrapper.arguments[0].body.body[0].declarations.length === 3 &&
-            wrapper.arguments[0].body.body[0].declarations.every((decl: any) => decl.init === null && decl.id.type === 'Identifier')
-        ) &&
-        wrapper.arguments[0].body.body[wrapper.arguments[0].body.body.length - 1].type === 'ReturnStatement' &&
-        wrapper.arguments[0].body.body[wrapper.arguments[0].body.body.length - 1].argument.type === 'CallExpression' &&
-        wrapper.arguments[0].body.body[wrapper.arguments[0].body.body.length - 1].argument.callee.type === 'CallExpression' &&
-        wrapper.arguments[0].body.body[wrapper.arguments[0].body.body.length - 1].argument.arguments.length &&
-        wrapper.arguments[0].body.body[wrapper.arguments[0].body.body.length - 1].argument.arguments.every((arg: any) => arg && arg.type === 'Literal' && typeof arg.value === 'number') &&
-        (
-          wrapper.arguments[0].body.body[wrapper.arguments[0].body.body.length - 1].argument.callee.callee.type === 'FunctionExpression' ||
-          wrapper.arguments[0].body.body[wrapper.arguments[0].body.body.length - 1].argument.callee.callee.type === 'CallExpression' &&
-          wrapper.arguments[0].body.body[wrapper.arguments[0].body.body.length - 1].argument.callee.callee.callee.type === 'FunctionExpression' &&
-          wrapper.arguments[0].body.body[wrapper.arguments[0].body.body.length - 1].argument.callee.callee.arguments.length === 0
-        ) &&
-        // (dont go deeper into browserify loader internals than this)
-        wrapper.arguments[0].body.body[wrapper.arguments[0].body.body.length - 1].argument.callee.arguments.length === 3 &&
-        wrapper.arguments[0].body.body[wrapper.arguments[0].body.body.length - 1].argument.callee.arguments[0].type === 'ObjectExpression' &&
-        wrapper.arguments[0].body.body[wrapper.arguments[0].body.body.length - 1].argument.callee.arguments[1].type === 'ObjectExpression' &&
-        wrapper.arguments[0].body.body[wrapper.arguments[0].body.body.length - 1].argument.callee.arguments[2].type === 'ArrayExpression') {
-      const modules = wrapper.arguments[0].body.body[wrapper.arguments[0].body.body.length - 1].argument.callee.arguments[0].properties;
+            wrapper.arguments[0].body.body[0].declarations.every(decl => decl.init === null && decl.id.type === 'Identifier')
+        ) && getLastReturnCalleeArgumentProps(wrapper.arguments[0].body.body)) {
+      const modules = getLastReturnCalleeArgumentProps(wrapper.arguments[0].body.body) || [];
 
       // verify modules is the expected data structure
       // in the process, extract external requires
-      const externals: Record<string, Node> = {};
-      if (modules.every((m: any) => {
+      const externals: Record<string, Literal> = {};
+      if (modules.every(m => {
         if (m.type !== 'Property' ||
             m.computed !== false ||
             m.key.type !== 'Literal' ||
             typeof m.key.value !== 'number' ||
             m.value.type !== 'ArrayExpression' ||
             m.value.elements.length !== 2 ||
+            !m.value.elements[0] ||
+            !m.value.elements[1] ||
             m.value.elements[0].type !== 'FunctionExpression' ||
             m.value.elements[1].type !== 'ObjectExpression') {
           return false;
@@ -164,24 +183,33 @@ export function handleWrappers(ast: Node) {
             return false;
           }
           if (isUndefinedOrVoid(prop.value)) {
-            if (prop.key.type === 'Identifier')
+            if (prop.key.type === 'Identifier') {
               externals[prop.key.name] = {
                 type: 'Literal',
+                // @ts-ignore start can be undefined
                 start: prop.key.start,
+                // @ts-ignore end can be undefined
                 end: prop.key.end,
                 value: prop.key.name,
                 raw: JSON.stringify(prop.key.name)
               };
-            else if (prop.key.type === 'Literal')
-              externals[prop.key.value] = prop.key;
+            } else if (prop.key.type === 'Literal') {
+              externals[String(prop.key.value)] = prop.key;
+            }
           }
         }
         return true;
       })) {
         // if we have externals, inline them into the browserify cache for webpack to pick up
         const externalIds = Object.keys(externals);
-        if (externalIds.length) {
-          const cache = (wrapper.arguments[0].body.body[1] || wrapper.arguments[0].body.body[0]).argument.callee.arguments[1];
+        const argBody = (wrapper.arguments[0].body.body[1] || wrapper.arguments[0].body.body[0]);
+        if (externalIds.length &&
+            argBody &&
+            'argument' in argBody &&
+            argBody.argument &&
+            'callee' in argBody.argument &&
+            'arguments' in argBody.argument.callee) {
+          const cache = argBody.argument.callee.arguments[1];
           cache.properties = externalIds.map(ext => {
             return {
               type: 'Property',
@@ -239,6 +267,9 @@ export function handleWrappers(ast: Node) {
         wrapper.arguments[0].params.length === 2 &&
         wrapper.arguments[0].params[0].type === 'Identifier' &&
         wrapper.arguments[0].params[1].type === 'Identifier' &&
+        'body' in wrapper.callee &&
+        'body' in wrapper.callee.body &&
+        Array.isArray(wrapper.callee.body.body) &&
         wrapper.callee.body.body.length === 1) {
       const statement = wrapper.callee.body.body[0];
       if (statement.type === 'IfStatement' &&
@@ -278,16 +309,23 @@ export function handleWrappers(ast: Node) {
             callSite = statement.consequent.body[0].expression.right;
           if (callSite &&
               callSite.callee.type === 'Identifier' &&
+              'params' in wrapper.callee &&
               wrapper.callee.params.length > 0 &&
+              'name' in wrapper.callee.params[0] &&
               callSite.callee.name === wrapper.callee.params[0].name &&
               callSite.arguments.length === 2 &&
               callSite.arguments[0].type === 'Identifier' &&
               callSite.arguments[0].name === 'require' &&
               callSite.arguments[1].type === 'Identifier' &&
               callSite.arguments[1].name === 'exports') {
-            delete wrapper.arguments[0].scope.declarations.require;
-            delete wrapper.arguments[0].scope.declarations.exports;
-            wrapper.arguments[0].params = [];
+            const funcExpression = wrapper.arguments[0];
+            funcExpression.params = [];
+            try {
+              // @ts-ignore If scope doesn't exist thats ok
+              const scope = funcExpression.scope;
+              delete scope.declarations.require;
+              delete scope.declarations.exports;
+            } catch (e) {}
           }
       }
     }
@@ -357,11 +395,11 @@ export function handleWrappers(ast: Node) {
           wrapper.arguments[0] && (
             wrapper.arguments[0].type === 'ArrayExpression' &&
             wrapper.arguments[0].elements.length > 0 &&
-            wrapper.arguments[0].elements.every((el: any) => el && el.type === 'FunctionExpression') ||
+            wrapper.arguments[0].elements.every(el => el && el.type === 'FunctionExpression') ||
             wrapper.arguments[0].type === 'ObjectExpression' &&
             wrapper.arguments[0].properties &&
             wrapper.arguments[0].properties.length > 0 &&
-            wrapper.arguments[0].properties.every((prop: any) => prop && prop.key && prop.key.type === 'Literal' && prop.value && prop.value.type === 'FunctionExpression')
+            wrapper.arguments[0].properties.every(prop => prop && prop.type === 'Property' && prop.key && prop.key.type === 'Literal' && prop.value && prop.value.type === 'FunctionExpression')
           )
         ) ||
         wrapper.arguments.length === 0 &&
@@ -386,21 +424,27 @@ export function handleWrappers(ast: Node) {
         wrapper.callee.body.body[3].expression.right.type === 'ObjectExpression' &&
         (wrapper.callee.body.body[4].type === 'VariableDeclaration' &&
           wrapper.callee.body.body[4].declarations.length === 1 &&
+          wrapper.callee.body.body[4].declarations[0].init &&
           wrapper.callee.body.body[4].declarations[0].init.type === 'CallExpression' &&
           wrapper.callee.body.body[4].declarations[0].init.callee.type === 'Identifier' &&
           wrapper.callee.body.body[4].declarations[0].init.callee.name === 'require' ||
           wrapper.callee.body.body[5].type === 'VariableDeclaration' &&
           wrapper.callee.body.body[5].declarations.length === 1 &&
+          wrapper.callee.body.body[5].declarations[0].init &&
           wrapper.callee.body.body[5].declarations[0].init.type === 'CallExpression' &&
           wrapper.callee.body.body[5].declarations[0].init.callee.type === 'Identifier' &&
           wrapper.callee.body.body[5].declarations[0].init.callee.name === 'require')) {
       const externalMap = new Map<number, any>();
-      const moduleObj = wrapper.callee.params.length ? wrapper.arguments[0] : wrapper.callee.body.body[3].expression.right;
-      let modules: [number, any][];
+      const statement = wrapper.callee.body.body[3];
+      if (statement.type !== 'ExpressionStatement' || statement.expression.type !== 'AssignmentExpression' || statement.expression.right.type !== 'ObjectExpression') {
+        throw new Error('Expected ExpressionStatement');
+      }
+      const moduleObj = wrapper.callee.params.length ? wrapper.arguments[0] : statement.expression.right;
+      let modules: [number, typeof moduleObj][];
       if (moduleObj.type === 'ArrayExpression')
-        modules = moduleObj.elements.map((el: any, i: number) => [i, el]);
+        modules = moduleObj.elements.map((el, i) => [i, el]);
       else
-        modules = moduleObj.properties.map((prop: any) => [prop.key.value, prop.value]);
+        modules = 'properties' in moduleObj ? moduleObj.properties.map(prop => [prop.key.value, prop.value]) : [];
       for (const [k, m] of modules) {
         const statement = m.body.body.length === 1 ? m.body.body[0] :
             (m.body.body.length === 2 || m.body.body.length === 3 && m.body.body[2].type === 'EmptyStatement') &&
@@ -414,7 +458,9 @@ export function handleWrappers(ast: Node) {
             statement.expression.operator === '=' &&
             statement.expression.left.type === 'MemberExpression' &&
             statement.expression.left.object.type === 'Identifier' &&
+            'params' in m &&
             m.params.length > 0 &&
+            'name' in m.params[0] &&
             statement.expression.left.object.name === m.params[0].name &&
             statement.expression.left.property.type === 'Identifier' &&
             statement.expression.left.property.name === 'exports' &&
@@ -427,12 +473,13 @@ export function handleWrappers(ast: Node) {
         }
       }
       for (const [, m] of modules) {
-        if (m.params.length === 3 && m.params[2].type === 'Identifier') {
+        if ('params' in m && m.params.length === 3 && m.params[2].type === 'Identifier') {
           const assignedVars = new Map();
           walk(m.body, {
             enter (node, maybeParent) {
               if (node.type === 'CallExpression' &&
                   node.callee.type === 'Identifier' &&
+                  'name' in m.params[2] &&
                   node.callee.name === m.params[2].name &&
                   node.arguments.length === 1 &&
                   node.arguments[0].type === 'Literal') {
@@ -475,6 +522,7 @@ export function handleWrappers(ast: Node) {
               else if (node.type === 'CallExpression' &&
                   node.callee.type === 'MemberExpression' &&
                   node.callee.object.type === 'Identifier' &&
+                  'name' in m.params[2] &&
                   node.callee.object.name === m.params[2].name &&
                   node.callee.property.type === 'Identifier' &&
                   node.callee.property.name === 'n' &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -1942,6 +1942,11 @@
   dependencies:
     "@types/express" "*"
 
+"@types/estree@^0.0.47":
+  version "0.0.47"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.47.tgz#d7a51db20f0650efec24cd04994f523d93172ed4"
+  integrity sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==
+
 "@types/express-jwt@0.0.42":
   version "0.0.42"
   resolved "https://registry.yarnpkg.com/@types/express-jwt/-/express-jwt-0.0.42.tgz#4f04e1fadf9d18725950dc041808a4a4adf7f5ae"
@@ -2233,6 +2238,13 @@
   integrity sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==
   dependencies:
     "@types/yargs-parser" "*"
+
+"@types/yauzl@^2.9.1":
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.9.1.tgz#d10f69f9f522eef3cf98e30afb684a1e1ec923af"
+  integrity sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
+  dependencies:
+    "@types/node" "*"
 
 "@webcomponents/template@^1.4.0":
   version "1.4.4"
@@ -4315,6 +4327,11 @@ commander@^5.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
+commander@^6.1.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
+  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
+
 commander@~2.13.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
@@ -5883,6 +5900,17 @@ extract-zip@^1.6.5:
     mkdirp "^0.5.4"
     yauzl "^2.10.0"
 
+extract-zip@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
+  integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
+  dependencies:
+    debug "^4.1.1"
+    get-stream "^5.1.0"
+    yauzl "^2.10.0"
+  optionalDependencies:
+    "@types/yauzl" "^2.9.1"
+
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -6590,7 +6618,7 @@ get-stream@^4.0.0, get-stream@^4.1.0:
   dependencies:
     pump "^3.0.0"
 
-get-stream@^5.0.0:
+get-stream@^5.0.0, get-stream@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
   integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
@@ -8597,6 +8625,11 @@ jpeg-js@^0.3.4:
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.3.7.tgz#471a89d06011640592d314158608690172b1028d"
   integrity sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ==
+
+jpeg-js@^0.4.2:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.3.tgz#6158e09f1983ad773813704be80680550eff977b"
+  integrity sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q==
 
 js-library-detector@^5.5.0:
   version "5.9.0"
@@ -11856,6 +11889,26 @@ pkginfo@0.3.x:
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.3.1.tgz#5b29f6a81f70717142e09e765bbeab97b4f81e21"
   integrity sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=
 
+playwright-core@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.11.1.tgz#2a9ca6118ce94eccfc29dd4996cdc87bbac68eae"
+  integrity sha512-EQ/K7WucNHiL5AkFBLWNyIGWqPcD/m/k5LmYn5fgAf7mbInGTFkiZgQHibz+ZwEPb+NvcaEO7WVVZr3MrIzUpA==
+  dependencies:
+    commander "^6.1.0"
+    debug "^4.1.1"
+    extract-zip "^2.0.1"
+    https-proxy-agent "^5.0.0"
+    jpeg-js "^0.4.2"
+    mime "^2.4.6"
+    pngjs "^5.0.0"
+    progress "^2.0.3"
+    proper-lockfile "^4.1.1"
+    proxy-from-env "^1.1.0"
+    rimraf "^3.0.2"
+    stack-utils "^2.0.3"
+    ws "^7.3.1"
+    yazl "^2.5.1"
+
 please-upgrade-node@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
@@ -11872,6 +11925,11 @@ pngjs@^3.0.0, pngjs@^3.3.3:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.4.0.tgz#99ca7d725965fb655814eaf65f38f12bbdbf555f"
   integrity sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==
+
+pngjs@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-5.0.0.tgz#e79dd2b215767fd9c04561c01236df960bce7fbb"
+  integrity sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==
 
 polyfill-library@3.93.0:
   version "3.93.0"
@@ -12028,7 +12086,7 @@ progress@^1.1.8:
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
   integrity sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=
 
-progress@^2.0.0:
+progress@^2.0.0, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -12102,6 +12160,15 @@ prop-types@^15.6.2:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
+
+proper-lockfile@^4.1.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz#c8b9de2af6b2f1601067f98e01ac66baa223141f"
+  integrity sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    retry "^0.12.0"
+    signal-exit "^3.0.2"
 
 property-accessors@^1.1:
   version "1.1.3"
@@ -13946,7 +14013,7 @@ stack-trace@0.0.10:
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
   integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
 
-stack-utils@^2.0.2:
+stack-utils@^2.0.2, stack-utils@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.3.tgz#cd5f030126ff116b78ccb3c027fe302713b61277"
   integrity sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==
@@ -15809,6 +15876,11 @@ ws@^6.0.0:
   dependencies:
     async-limiter "~1.0.0"
 
+ws@^7.3.1:
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.5.tgz#a484dd851e9beb6fdb420027e3885e8ce48986c1"
+  integrity sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==
+
 ws@^7.4.4, ws@~7.4.2:
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.4.tgz#383bc9742cb202292c9077ceab6f6047b17f2d59"
@@ -16145,6 +16217,13 @@ yauzl@^2.10.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yazl@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.5.1.tgz#a3d65d3dd659a5b0937850e8609f22fffa2b5c35"
+  integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==
+  dependencies:
+    buffer-crc32 "~0.2.3"
 
 yeast@0.1.2:
   version "0.1.2"


### PR DESCRIPTION
We've had several null/undefined bugs (such as #212) that can be avoided with better TS types.

This PR adds `@types/estree` as suggested by @sokra [a few years ago](https://github.com/acornjs/acorn/issues/741#issuecomment-426260204) and this seems to do the trick.