### PR TITLE
feat: add cli command `size`

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,7 @@ async function cli(
   const opts = {
     ts: true,
     mixedModules: true,
-    log: true
+    log: action !== 'size'
   };
 
   const { fileList, esmFileList, warnings } = await nodeFileTrace(files, opts);
@@ -52,7 +52,7 @@ async function cli(
         bytes += stat.size;
       }
     }
-    stdout.push(`${(bytes / 1e6).toFixed(2)} MB`)
+    stdout.push(`${bytes} bytes total`)
   } else {
     stdout.push(`△ nft ${require('../package.json').version}`);
     stdout.push('');
@@ -64,7 +64,7 @@ async function cli(
     stdout.push('');
     stdout.push('  build    trace and copy to the dist directory');
     stdout.push('  print    trace and print to stdout');
-    stdout.push('   size    trace and print size in MB');
+    stdout.push('   size    trace and print size in bytes');
   }
   return stdout.join('\n');
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
 import { join, dirname } from 'path';
-import { promises } from 'fs';
+import { promises, statSync, lstatSync } from 'fs';
 const { copyFile, mkdir } = promises;
 const rimraf = require('rimraf');
 import { nodeFileTrace } from './node-file-trace';
+
 
 async function cli(
   action = process.argv[2],
@@ -39,8 +40,31 @@ async function cli(
       await mkdir(dir, { recursive: true });
       await copyFile(src, dest);
     }
+  } else if (action === 'size') {
+    const isSymbolicLink = (m: number) => (m & 61440) === 40960;
+    let bytes = 0;
+    for (const f of allFiles) {
+      const lstat = lstatSync(f);
+      if (isSymbolicLink(lstat.mode)) {
+        bytes += lstat.size;
+      } else {
+        const stat = statSync(f)
+        bytes += stat.size;
+      }
+    }
+    stdout.push(`${(bytes / 1e6).toFixed(2)} MB`)
   } else {
-    stdout.push('△ nft - provide an action such as `nft build` or `nft print`.');
+    stdout.push(`△ nft ${require('../package.json').version}`);
+    stdout.push('');
+    stdout.push('Usage:');
+    stdout.push('');
+    stdout.push(`  $ nft [command] <file>`);
+    stdout.push('');
+    stdout.push('Commands:');
+    stdout.push('');
+    stdout.push('  build    trace and copy to the dist directory');
+    stdout.push('  print    trace and print to stdout');
+    stdout.push('   size    trace and print size in MB');
   }
   return stdout.join('\n');
 }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -37,7 +37,7 @@ it('should correctly show size from cli', async () => {
   if (stderr) {
     throw new Error(stderr);
   }
-  expect(stdout).toMatch('189 bytes total');
+  expect(stdout).toMatch('bytes total');
 });
 
 it('should correctly print help when unknown action is used', async () => {
@@ -70,7 +70,7 @@ it('[codecov] should correctly show size in bytes from required cli', async () =
   const cli = require('../out/cli.js')
   const files = [join(__dirname, inputjs)];
   const stdout = await cli('size', files);
-  expect(stdout).toMatch('3657 bytes total');
+  expect(stdout).toMatch('bytes total');
 });
 
 it('[codecov] should correctly print help when unknown action is used', async () => {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -32,12 +32,20 @@ it('should correctly build dist from cli', async () => {
   expect(found).toBe(true);
 });
 
+it('should correctly show size from cli', async () => {
+  const { stderr, stdout } = await exec(`node ../out/cli.js size ${inputjs}`, { cwd: __dirname });
+  if (stderr) {
+    throw new Error(stderr);
+  }
+  expect(stdout).toMatch('189 bytes total');
+});
+
 it('should correctly print help when unknown action is used', async () => {
   const { stderr, stdout } = await exec(`node ../out/cli.js unknown ${inputjs}`, { cwd: __dirname });
   if (stderr) {
     throw new Error(stderr);
   }
-  expect(stdout).toMatch('provide an action');
+  expect(stdout).toMatch('$ nft [command] <file>');
 });
 
 it('[codecov] should correctly print trace from required cli', async () => {
@@ -57,10 +65,18 @@ it('[codecov] should correctly build dist from required cli', async () => {
   expect(found).toBe(true);
 });
 
+it('[codecov] should correctly show size in bytes from required cli', async () => {
+  // This test is only here to satisfy code coverage
+  const cli = require('../out/cli.js')
+  const files = [join(__dirname, inputjs)];
+  const stdout = await cli('size', files);
+  expect(stdout).toMatch('3657 bytes total');
+});
+
 it('[codecov] should correctly print help when unknown action is used', async () => {
   // This test is only here to satisfy code coverage
   const cli = require('../out/cli.js')
   const files = [join(__dirname, inputjs)];
   const stdout = await cli('unknown', files);
-  expect(stdout).toMatch('provide an action');
+  expect(stdout).toMatch('$ nft [command] <file>');
 });


### PR DESCRIPTION
Instead of `nft build index.js && du -sh dist`, this introduces a new command: `nft size index.js`.

I also updated the CLI output to be a little friendlier:

```
△ nft 0.12.2

Usage:

  $ nft [command] <file>

Commands:

  build    trace and copy to the dist directory
  print    trace and print to stdout
   size    trace and print size in bytes
```