### PR TITLE
fix: remove internal types on publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "prepublishOnly": "tsc && rm out/tsconfig.tsbuildinfo",
+    "prepublishOnly": "tsc && rm out/utils/*.d.ts && rm out/tsconfig.tsbuildinfo",
     "test": "jest --verbose",
     "test-verbose": "tsc --sourceMap && jest --verbose --coverage --globals \"{\\\"coverage\\\":true}\"",
     "codecov": "codecov"

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -28,7 +28,7 @@ const acorn = Parser.extend(
 import os from 'os';
 import { handleWrappers } from './utils/wrappers';
 import resolveFrom from 'resolve-from';
-import { ConditionalValue, EvaluatedValue, StaticValue, Ast } from './types';
+import { ConditionalValue, EvaluatedValue, StaticValue, Ast } from './utils/types';
 
 const staticProcess = {
   cwd: () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 import { Job } from './node-file-trace';
-import { Node as TreeNode } from 'estree';
 
 export interface Stats {
   isFile(): boolean;
@@ -66,18 +65,3 @@ export interface NodeFileTraceResult {
   reasons: NodeFileTraceReasons;
   warnings: Error[];
 }
-
-export interface StaticValue {
-  value: any;
-  wildcards?: string[];
-}
-
-export interface ConditionalValue {
-  test: string;
-  then: any;
-  else: any;
-}
-
-export type EvaluatedValue = StaticValue | ConditionalValue | undefined;
-
-export type Ast = { body: TreeNode[] };

--- a/src/utils/special-cases.ts
+++ b/src/utils/special-cases.ts
@@ -3,7 +3,7 @@ import resolveDependency from '../resolve-dependency';
 import { getPackageName } from './get-package-base';
 import { readFileSync } from 'fs';
 import { Job } from '../node-file-trace';
-import { Ast } from '../types';
+import { Ast } from './types';
 type Node = Ast['body'][0]
 
 const specialCases: Record<string, (o: SpecialCaseOpts) => void> = {

--- a/src/utils/static-eval.ts
+++ b/src/utils/static-eval.ts
@@ -1,5 +1,5 @@
 import { Node } from 'estree-walker';
-import { EvaluatedValue, StaticValue, ConditionalValue } from '../types';
+import { EvaluatedValue, StaticValue, ConditionalValue } from './types';
 import { URL } from 'url';
 type Walk = (node: Node) => EvaluatedValue;
 type State = { computeBranches: boolean, vars: Record<string, any> };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,16 @@
+import { Node as ESTreeNode } from 'estree';
+export type Ast = { body: ESTreeNode[] };
+
+
+export interface StaticValue {
+    value: any;
+    wildcards?: string[];
+  }
+  
+  export interface ConditionalValue {
+    test: string;
+    then: any;
+    else: any;
+  }
+  
+  export type EvaluatedValue = StaticValue | ConditionalValue | undefined;

--- a/src/utils/wrappers.ts
+++ b/src/utils/wrappers.ts
@@ -1,5 +1,5 @@
 import { walk, Node as ESNode } from 'estree-walker';
-import { Ast } from '../types';
+import { Ast } from './types';
 import { SimpleCallExpression, Node, Literal, FunctionExpression, ReturnStatement, ObjectExpression, ArrayExpression, Property, CallExpression } from 'estree';
 
 function isUndefinedOrVoid (node: Node) {


### PR DESCRIPTION
Fixes consumers using TS failing with

```
Error: ../../node_modules/@vercel/nft/out/types.d.ts(3,34): error TS2307: Cannot find module 'estree' or its corresponding type declarations.
Error: Command failed: tsc
```

This moves internal types to `./utils/types.ts` and deletes those upon publishing.

The external types will continue to live in `./types.ts`.