### PR TITLE
feat: private fields support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@mapbox/node-pre-gyp": "^1.0.5",
     "acorn": "^8.3.0",
     "acorn-class-fields": "^1.0.0",
+    "acorn-private-class-elements": "^1.0.0",
     "acorn-static-class-features": "^1.0.0",
     "bindings": "^1.4.0",
     "estree-walker": "^0.6.1",

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -23,6 +23,7 @@ import { fileURLToPath, pathToFileURL, URL } from 'url';
 const acorn = Parser.extend(
   require("acorn-class-fields"),
   require("acorn-static-class-features"),
+  require("acorn-private-class-elements")
 );
 
 import os from 'os';

--- a/test/ecmascript.test.js
+++ b/test/ecmascript.test.js
@@ -13,20 +13,6 @@ console.log('created directory ' + tmpdir);
 
  // These are tests known to fail so we skip them
 const ignoreCategories = new Set([
-  'bind (::) operator',
-  'additional meta properties',
-  'syntactic tail calls',
-  'object shorthand improvements',
-  'throw expressions',
-  'partial application syntax',
-  'Object.freeze and Object.seal syntax',
-  'Class and Property Decorators',
-  'the pipeline operator',
-  'Generator function.sent Meta Property',
-  'Logical Assignment',
-  'private class methods',
-  'Class static initialization blocks',
-  'Ergonomic brand checks for private fields',
 ]);
 
 async function runTests(importPath) {


### PR DESCRIPTION
Adds the acorn plugin for private fields and removes the ignored ecmascript tests.

It turns out a lot of the previously ignored tests are no longer present as well so there are currently no ignores!