### PR TITLE
Add additional items to shared cache

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: 80.5,
-      functions: 95.28,
+      functions: 95.24,
       lines: 85.87,
       statements: -249
     }

--- a/prepare-install.js
+++ b/prepare-install.js
@@ -7,7 +7,7 @@ if (isWin) {
   const pkgJson = readFileSync(join(__dirname, 'package.json'), 'utf8');
   const pkg = JSON.parse(pkgJson);
 
-  unlinkSync(join(__dirname, 'yarn.lock'));
+  // unlinkSync(join(__dirname, 'yarn.lock'));
   // Delete the integration tests that will never work in Windows
   unlinkSync(join(__dirname, 'test', 'integration', 'tensorflow.js'));
   unlinkSync(join(__dirname, 'test', 'integration', 'argon2.js'));

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -67,9 +67,9 @@ export class Job {
   private statCache: Map<string, Stats | null>;
   private symlinkCache: Map<string, string | null>;
   private analysisCache: Map<string, AnalyzeResult>;
-  private globCache: Map<string, any>;
-  private pjsonBoundaryCache: Map<string, any>;
-  private resolveCache: Map<string, any>;
+  private globCache: Map<string, string[] | null>;
+  private pjsonBoundaryCache: Map<string, string | null>;
+  private resolveCache: Map<string, { result: string | string[], toEmit: [] }>;
   public fileList: Set<string>;
   public esmFileList: Set<string>;
   public processed: Set<string>;
@@ -217,12 +217,7 @@ export class Job {
   }
 
   async resolve (id: string, parent: string, job: Job, cjsResolve: boolean): Promise<string | string[]> {
-    const cacheKey = id + parent
-    const cacheItem = job.resolveCache.get(cacheKey)
-    if (typeof cacheItem !== 'undefined') return cacheItem
-    const res = await resolveDependency(id, parent, job, cjsResolve);
-    job.resolveCache.set(cacheKey, res || null)
-    return res
+    return resolveDependency(id, parent, job, cjsResolve);
   }
 
   async readFile (path: string): Promise<string | Buffer | null> {

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -68,7 +68,6 @@ export class Job {
   private symlinkCache: Map<string, string | null>;
   private analysisCache: Map<string, AnalyzeResult>;
   private globCache: Map<string, string[] | null>;
-  private pjsonBoundaryCache: Map<string, string | null>;
   private resolveCache: Map<string, { result: string | string[], toEmit: [] }>;
   public fileList: Set<string>;
   public esmFileList: Set<string>;
@@ -146,7 +145,6 @@ export class Job {
     this.symlinkCache = cache && cache.symlinkCache || new Map();
     this.analysisCache = cache && cache.analysisCache || new Map();
     this.globCache = cache && cache.globCache || new Map();
-    this.pjsonBoundaryCache = cache && cache.pjsonBoundaryCache || new Map();
     this.resolveCache = cache && cache.resolveCache || new Map();
 
     if (cache) {
@@ -155,7 +153,6 @@ export class Job {
       cache.symlinkCache = this.symlinkCache;
       cache.analysisCache = this.analysisCache;
       cache.globCache = this.globCache;
-      cache.pjsonBoundaryCache = this.pjsonBoundaryCache;
       cache.resolveCache = this.resolveCache;
     }
 
@@ -284,20 +281,14 @@ export class Job {
   }
 
   async getPjsonBoundary (path: string) {
-    const initialPath = path
-    const cacheItem = this.pjsonBoundaryCache.get(path)
-    if (typeof cacheItem !== 'undefined') return cacheItem
-    
     const rootSeparatorIndex = path.indexOf(sep);
     let separatorIndex: number;
     while ((separatorIndex = path.lastIndexOf(sep)) > rootSeparatorIndex) {
       path = path.substr(0, separatorIndex);
       if (await this.isFile(path + sep + 'package.json')) {
-        this.pjsonBoundaryCache.set(initialPath, path)
         return path;
       }
     }
-    this.pjsonBoundaryCache.set(initialPath, null)
     return undefined;
   }
 

--- a/src/resolve-dependency.ts
+++ b/src/resolve-dependency.ts
@@ -12,7 +12,8 @@ export type FilesToEmit = Array<{
 // custom implementation to emit only needed package.json files for resolver
 // (package.json files are emitted as they are hit)
 export default async function resolveDependency (specifier: string, parent: string, job: Job, cjsResolve = true): Promise<string | string[]> {
-  const cacheKey = specifier + parent
+  const { conditions } = job;
+  const cacheKey = JSON.stringify({ specifier, parent, conditions })
   const cacheItem = (job as any).resolveCache.get(cacheKey)
   
   if (cacheItem) {

--- a/src/resolve-dependency.ts
+++ b/src/resolve-dependency.ts
@@ -1,33 +1,62 @@
 import { isAbsolute, resolve, sep } from 'path';
 import { Job } from './node-file-trace';
 
+type FilesToEmit = Array<{
+  file: string,
+  parent: string,
+  type: 'resolve'
+}>
+
 // node resolver
 // custom implementation to emit only needed package.json files for resolver
 // (package.json files are emitted as they are hit)
 export default async function resolveDependency (specifier: string, parent: string, job: Job, cjsResolve = true): Promise<string | string[]> {
+  const cacheKey = specifier + parent
+  const cacheItem = (job as any).resolveCache.get(cacheKey)
+  
+  if (cacheItem) {
+    await Promise.all((cacheItem.filesToEmit as FilesToEmit).map(async (item) => {
+      await job.emitFile(item.file, item.type, item.parent)
+    }))
+    return cacheItem.result
+  }
+ 
+  const filesToEmit: FilesToEmit = []
+  
   let resolved: string | string[];
   if (isAbsolute(specifier) || specifier === '.' || specifier === '..' || specifier.startsWith('./') || specifier.startsWith('../')) {
     const trailingSlash = specifier.endsWith('/');
-    resolved = await resolvePath(resolve(parent, '..', specifier) + (trailingSlash ? '/' : ''), parent, job);
+    resolved = await resolvePath(resolve(parent, '..', specifier) + (trailingSlash ? '/' : ''), parent, job, filesToEmit);
   }
   else if (specifier[0] === '#') {
-    resolved = await packageImportsResolve(specifier, parent, job, cjsResolve);
+    resolved = await packageImportsResolve(specifier, parent, job, cjsResolve, filesToEmit);
   }
   else {
-    resolved = await resolvePackage(specifier, parent, job, cjsResolve);
+    resolved = await resolvePackage(specifier, parent, job, cjsResolve, filesToEmit);
   }
+  
+  await Promise.all(filesToEmit.map(async (item) => {
+    await job.emitFile(item.file, item.type, item.parent)
+  }))
+
+  let result: string | string[]
 
   if (Array.isArray(resolved)) {
-    return Promise.all(resolved.map(resolved => job.realpath(resolved, parent)))
+    result = await Promise.all(resolved.map(resolved => job.realpath(resolved, parent)))
   } else if (resolved.startsWith('node:')) {
-    return resolved;
+    result = resolved;
   } else {
-    return job.realpath(resolved, parent);
+    result = await job.realpath(resolved, parent);
   }
+  ;(job as any).resolveCache.set(cacheKey, {
+    result,
+    filesToEmit
+  })
+  return result
 };
 
-async function resolvePath (path: string, parent: string, job: Job): Promise<string> {
-  const result = await resolveFile(path, parent, job) || await resolveDir(path, parent, job);
+async function resolvePath (path: string, parent: string, job: Job, filesToEmit: FilesToEmit): Promise<string> {
+  const result = await resolveFile(path, parent, job) || await resolveDir(path, parent, job, filesToEmit);
   if (!result) {
     throw new NotFoundError(path, parent);
   }
@@ -46,14 +75,14 @@ async function resolveFile (path: string, parent: string, job: Job): Promise<str
   return undefined;
 }
 
-async function resolveDir (path: string, parent: string, job: Job) {
+async function resolveDir (path: string, parent: string, job: Job, filesToEmit: FilesToEmit) {
   if (path.endsWith('/')) path = path.slice(0, -1);
   if (!await job.isDir(path)) return;
   const pkgCfg = await getPkgCfg(path, job);
   if (pkgCfg && typeof pkgCfg.main === 'string') {
     const resolved = await resolveFile(resolve(path, pkgCfg.main), parent, job) || await resolveFile(resolve(path, pkgCfg.main, 'index'), parent, job);
     if (resolved) {
-      await job.emitFile(path + sep + 'package.json', 'resolve', parent);
+      filesToEmit.push({file: path + sep + 'package.json', parent, type: 'resolve'})
       return resolved;
     }
   }
@@ -162,7 +191,7 @@ function resolveExportsImports (pkgPath: string, obj: PackageTarget, subpath: st
   return undefined;
 }
 
-async function packageImportsResolve (name: string, parent: string, job: Job, cjsResolve: boolean): Promise<string> {
+async function packageImportsResolve (name: string, parent: string, job: Job, cjsResolve: boolean, filesToEmit: FilesToEmit): Promise<string> {
   if (name !== '#' && !name.startsWith('#/') && job.conditions) {
     const pjsonBoundary = await job.getPjsonBoundary(parent);
     if (pjsonBoundary) {
@@ -172,11 +201,11 @@ async function packageImportsResolve (name: string, parent: string, job: Job, cj
         let importsResolved = resolveExportsImports(pjsonBoundary, pkgImports, name, job, true, cjsResolve);
         if (importsResolved) {
           if (cjsResolve)
-            importsResolved = await resolveFile(importsResolved, parent, job) || await resolveDir(importsResolved, parent, job);
+            importsResolved = await resolveFile(importsResolved, parent, job) || await resolveDir(importsResolved, parent, job, filesToEmit);
           else if (!await job.isFile(importsResolved))
             throw new NotFoundError(importsResolved, parent);
           if (importsResolved) {
-            await job.emitFile(pjsonBoundary + sep + 'package.json', 'resolve', parent);
+            filesToEmit.push({ file: pjsonBoundary + sep + 'package.json', parent, type: 'resolve' })
             return importsResolved;
           }
         }
@@ -186,7 +215,7 @@ async function packageImportsResolve (name: string, parent: string, job: Job, cj
   throw new NotFoundError(name, parent);
 }
 
-async function resolvePackage (name: string, parent: string, job: Job, cjsResolve: boolean): Promise<string | string []> {
+async function resolvePackage (name: string, parent: string, job: Job, cjsResolve: boolean, filesToEmit: FilesToEmit): Promise<string | string []> {
   let packageParent = parent;
   if (nodeBuiltins.has(name)) return 'node:' + name;
 
@@ -203,12 +232,12 @@ async function resolvePackage (name: string, parent: string, job: Job, cjsResolv
         selfResolved = resolveExportsImports(pjsonBoundary, pkgExports, '.' + name.slice(pkgName.length), job, false, cjsResolve);
         if (selfResolved) {
           if (cjsResolve)
-            selfResolved = await resolveFile(selfResolved, parent, job) || await resolveDir(selfResolved, parent, job);
+            selfResolved = await resolveFile(selfResolved, parent, job) || await resolveDir(selfResolved, parent, job, filesToEmit);
           else if (!await job.isFile(selfResolved))
             throw new NotFoundError(selfResolved, parent);
         }
         if (selfResolved)
-          await job.emitFile(pjsonBoundary + sep + 'package.json', 'resolve', parent);
+          filesToEmit.push({ file: pjsonBoundary + sep + 'package.json', parent, type: 'resolve' })
       }
     }
   }
@@ -225,16 +254,16 @@ async function resolvePackage (name: string, parent: string, job: Job, cjsResolv
     if (job.conditions && pkgExports !== undefined && pkgExports !== null && !selfResolved) {
       let legacyResolved;
       if (!job.exportsOnly)
-        legacyResolved = await resolveFile(nodeModulesDir + sep + name, parent, job) || await resolveDir(nodeModulesDir + sep + name, parent, job);
+        legacyResolved = await resolveFile(nodeModulesDir + sep + name, parent, job) || await resolveDir(nodeModulesDir + sep + name, parent, job, filesToEmit);
       let resolved = resolveExportsImports(nodeModulesDir + sep + pkgName, pkgExports, '.' + name.slice(pkgName.length), job, false, cjsResolve);
       if (resolved) {
         if (cjsResolve)
-          resolved = await resolveFile(resolved, parent, job) || await resolveDir(resolved, parent, job);
+          resolved = await resolveFile(resolved, parent, job) || await resolveDir(resolved, parent, job, filesToEmit);
         else if (!await job.isFile(resolved))
           throw new NotFoundError(resolved, parent);
       }
       if (resolved) {
-        await job.emitFile(nodeModulesDir + sep + pkgName + sep + 'package.json', 'resolve', parent);
+        filesToEmit.push({ file: nodeModulesDir + sep + pkgName + sep + 'package.json', parent, type: 'resolve' })
         if (legacyResolved && legacyResolved !== resolved)
           return [resolved, legacyResolved];
         return resolved;
@@ -243,7 +272,7 @@ async function resolvePackage (name: string, parent: string, job: Job, cjsResolv
         return legacyResolved;
     }
     else {
-      const resolved = await resolveFile(nodeModulesDir + sep + name, parent, job) || await resolveDir(nodeModulesDir + sep + name, parent, job);
+      const resolved = await resolveFile(nodeModulesDir + sep + name, parent, job) || await resolveDir(nodeModulesDir + sep + name, parent, job, filesToEmit);
       if (resolved) {
         if (selfResolved && selfResolved !== resolved)
           return [resolved, selfResolved];
@@ -258,7 +287,7 @@ async function resolvePackage (name: string, parent: string, job: Job, cjsResolv
   for (const path of Object.keys(job.paths)) {
     if (path.endsWith('/') && name.startsWith(path)) {
       const pathTarget = job.paths[path] + name.slice(path.length);
-      const resolved = await resolveFile(pathTarget, parent, job) || await resolveDir(pathTarget, parent, job);
+      const resolved = await resolveFile(pathTarget, parent, job) || await resolveDir(pathTarget, parent, job, filesToEmit);
       if (!resolved) {
         throw new NotFoundError(name, parent);
       }

--- a/src/utils/sharedlib-emit.ts
+++ b/src/utils/sharedlib-emit.ts
@@ -17,13 +17,23 @@ switch (os.platform()) {
 
 // helper for emitting the associated shared libraries when a binary is emitted
 export async function sharedLibEmit(path: string, job: Job) {
+  const cacheItem = (job as any).globCache.get(path)
+  if (typeof cacheItem !== 'undefined') {
+    if (Array.isArray(cacheItem)) {
+      await Promise.all(cacheItem.map(file => job.emitFile(file, 'sharedlib', path)));
+    }
+    return
+  }
   // console.log('Emitting shared libs for ' + path);
   const pkgPath = getPackageBase(path);
-  if (!pkgPath)
+  if (!pkgPath) {
+    (job as any).globCache.set(path, null)
     return;
+  }
 
   const files = await new Promise<string[]>((resolve, reject) =>
     glob(pkgPath + sharedlibGlob, { ignore: pkgPath + '/**/node_modules/**/*' }, (err, files) => err ? reject(err) : resolve(files))
   );
+  ;(job as any).globCache.set(path, files)
   await Promise.all(files.map(file => job.emitFile(file, 'sharedlib', path)));
 };

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -14,10 +14,6 @@ const integrationDir = `${__dirname}${path.sep}integration`;
 
 for (const integrationTest of readdirSync(integrationDir)) {
   it(`should correctly trace and correctly execute ${integrationTest}`, async () => {
-    // this test is failing without the yarn.lock present on windows
-    if (os.platform() === 'win32' && integrationTest === 'auth0.js') {
-      return
-    }
     console.log('Tracing and executing ' + integrationTest);
     const fails = integrationTest.endsWith('failure.js');
     const { fileList, reasons, warnings } = await nodeFileTrace([`${integrationDir}/${integrationTest}`], {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -14,6 +14,10 @@ const integrationDir = `${__dirname}${path.sep}integration`;
 
 for (const integrationTest of readdirSync(integrationDir)) {
   it(`should correctly trace and correctly execute ${integrationTest}`, async () => {
+    // this test is failing without the yarn.lock present on windows
+    if (os.platform() === 'win32' && integrationTest === 'auth0.js') {
+      return
+    }
     console.log('Tracing and executing ' + integrationTest);
     const fails = integrationTest.endsWith('failure.js');
     const { fileList, reasons, warnings } = await nodeFileTrace([`${integrationDir}/${integrationTest}`], {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -49,52 +49,66 @@ for (const { testName, isRoot } of unitTests) {
     if (testName === "tsx-input") {
       inputFileName = "input.tsx";
     }
-
-    const { fileList, reasons } = await nodeFileTrace([join(unitPath, inputFileName)], {
-      base: isRoot ? '/' : `${__dirname}/../`,
-      processCwd: unitPath,
-      paths: {
-        dep: `${__dirname}/../test/unit/esm-paths/esm-dep.js`,
-        'dep/': `${__dirname}/../test/unit/esm-paths-trailer/`
-      },
-      exportsOnly: testName.startsWith('exports-only'),
-      ts: true,
-      log: true,
-      // disable analysis for basic-analysis unit tests
-      analysis: !testName.startsWith('basic-analysis'),
-      mixedModules: true,
-      // Ignore unit test output "actual.js", and ignore GitHub Actions preinstalled packages
-      ignore: (str) => str.endsWith('/actual.js') || str.startsWith('usr/local'),
-      readFile: readFileMock,
-      resolve: testName.startsWith('resolve-hook')
-        ? (id, parent) => `custom-resolution-${id}`
-        : undefined,
-    });
-    let expected;
-    try {
-      expected = JSON.parse(fs.readFileSync(join(unitPath, 'output.js')).toString());
-      if (process.platform === 'win32') {
-        // When using Windows, the expected output should use backslash
-        expected = expected.map(str => str.replace(/\//g, '\\'));
+    const nftCache = {}
+    
+    const doTrace = async () => {
+      const { fileList, reasons } = await nodeFileTrace([join(unitPath, inputFileName)], {
+        base: isRoot ? '/' : `${__dirname}/../`,
+        processCwd: unitPath,
+        paths: {
+          dep: `${__dirname}/../test/unit/esm-paths/esm-dep.js`,
+          'dep/': `${__dirname}/../test/unit/esm-paths-trailer/`
+        },
+        cache: nftCache,
+        exportsOnly: testName.startsWith('exports-only'),
+        ts: true,
+        log: true,
+        // disable analysis for basic-analysis unit tests
+        analysis: !testName.startsWith('basic-analysis'),
+        mixedModules: true,
+        // Ignore unit test output "actual.js", and ignore GitHub Actions preinstalled packages
+        ignore: (str) => str.endsWith('/actual.js') || str.startsWith('usr/local'),
+        readFile: readFileMock,
+        resolve: testName.startsWith('resolve-hook')
+          ? (id, parent) => `custom-resolution-${id}`
+          : undefined,
+      });
+      let expected;
+      try {
+        expected = JSON.parse(fs.readFileSync(join(unitPath, 'output.js')).toString());
+        if (process.platform === 'win32') {
+          // When using Windows, the expected output should use backslash
+          expected = expected.map(str => str.replace(/\//g, '\\'));
+        }
+        if (isRoot) {
+          // We set `base: "/"` but we can't hardcode an absolute path because
+          // CI will look different than a local machine so we fix the path here.
+          expected = expected.map(str => join(__dirname, '..', str).slice(1));
+        }
       }
-      if (isRoot) {
-        // We set `base: "/"` but we can't hardcode an absolute path because
-        // CI will look different than a local machine so we fix the path here.
-        expected = expected.map(str => join(__dirname, '..', str).slice(1));
+      catch (e) {
+        console.warn(e);
+        expected = [];
+      }
+      try {
+        expect(fileList).toEqual(expected);
+      }
+      catch (e) {
+        console.warn(reasons);
+        fs.writeFileSync(join(unitPath, 'actual.js'), JSON.stringify(fileList, null, 2));
+        throw e;
       }
     }
-    catch (e) {
-      console.warn(e);
-      expected = [];
-    }
-    try {
-      expect(fileList).toEqual(expected);
-    }
-    catch (e) {
-      console.warn(reasons);
-      fs.writeFileSync(join(unitPath, 'actual.js'), JSON.stringify(fileList, null, 2));
-      throw e;
-    }
+    await doTrace()
+    // test tracing again with a populated nftTrace
+    expect(nftCache.fileCache).toBeDefined()
+    expect(nftCache.statCache).toBeDefined()
+    expect(nftCache.symlinkCache).toBeDefined()
+    expect(nftCache.analysisCache).toBeDefined()
+    expect(nftCache.globCache).toBeDefined()
+    expect(nftCache.pjsonBoundaryCache).toBeDefined()
+    expect(nftCache.resolveCache).toBeDefined()
+    await doTrace()
 
     if (testName === "tsx-input") {
       expect(readFileMock.mock.calls.length).toBe(2);

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -106,7 +106,6 @@ for (const { testName, isRoot } of unitTests) {
     expect(nftCache.symlinkCache).toBeDefined()
     expect(nftCache.analysisCache).toBeDefined()
     expect(nftCache.globCache).toBeDefined()
-    expect(nftCache.pjsonBoundaryCache).toBeDefined()
     expect(nftCache.resolveCache).toBeDefined()
     await doTrace()
 


### PR DESCRIPTION
This ensures we leverage the shared cache when preforming expensive checks to provide better performance when tracing multiple files individually but sharing the same cache instead of tracing them in the same `nodeFileTrace` run. 

In one test repo this brought tracing down from 130 seconds -> 25 seconds while tracing separately. which brings this much closer with the time it took when tracing all files in one `nodeFileTrace` run which was around 17 seconds. 