### PR TITLE
Fix caching with circular emitDependency

### DIFF
--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -15,9 +15,11 @@ const integrationDir = `${__dirname}${path.sep}integration`;
 for (const integrationTest of readdirSync(integrationDir)) {
   it(`should correctly trace and correctly execute ${integrationTest}`, async () => {
     console.log('Tracing and executing ' + integrationTest);
+    const nftCache = {}
     const fails = integrationTest.endsWith('failure.js');
     const { fileList, reasons, warnings } = await nodeFileTrace([`${integrationDir}/${integrationTest}`], {
       log: true,
+      cache: nftCache,
       base: path.resolve(__dirname, '..'),
       processCwd: integrationDir,
       // ignore other integration tests
@@ -52,5 +54,15 @@ for (const integrationTest of readdirSync(integrationDir)) {
     const code = await new Promise(resolve => ps.on('close', resolve));
     expect(code).toBe(fails ? 1 : 0);
     rimraf.sync(tmpdir);
+    
+    const cachedResult = await nodeFileTrace([`${integrationDir}/${integrationTest}`], {
+      log: true,
+      cache: nftCache,
+      base: path.resolve(__dirname, '..'),
+      processCwd: integrationDir,
+      // ignore other integration tests
+      ignore: ['test/integration/**']
+    });
+    expect(cachedResult.fileList).toEqual(fileList)
   });
 }


### PR DESCRIPTION
Follow-up to https://github.com/vercel/nft/pull/238 this ensures we handle caching for circular `emitDependency` calls correctly. This also enables testing of the shared caching against the integration suite as it was previously only being tested against the unit suite. 