### PR TITLE
chore: add ijjk as a codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Documentation
 # https://help.github.com/en/articles/about-code-owners
 
-*                 @lucleray @styfle @Timer
+*                 @ijjk @styfle


### PR DESCRIPTION
Luc and Timer haven't work on nft in a couple years so adding ijjk as a codeowner