### PR TITLE
fix: remove unused `mkdirp` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "glob": "^7.1.3",
     "graceful-fs": "^4.2.9",
     "micromatch": "^4.0.2",
-    "mkdirp": "^0.5.1",
     "node-gyp-build": "^4.2.2",
     "node-pre-gyp": "^0.13.0",
     "resolve-from": "^5.0.0",

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -2,9 +2,7 @@ const { promises, readdirSync, mkdirSync } = require('fs');
 const path = require('path');
 const { nodeFileTrace } = require('../out/node-file-trace');
 const os = require('os');
-const { promisify } = require('util');
 const rimraf = require('rimraf');
-const mkdirp = promisify(require('mkdirp'));
 const { readFile, writeFile, readlink, symlink } = promises;
 const { fork } = require('child_process');
 
@@ -39,7 +37,7 @@ for (const integrationTest of readdirSync(integrationDir)) {
       catch (e) {
         if (e.code !== 'EINVAL' && e.code !== 'UNKNOWN') throw e;
       }
-      mkdirp.sync(path.dirname(outPath));
+      mkdirSync(path.dirname(outPath), { recursive: true });
       if (symlinkPath) {
         await symlink(symlinkPath, outPath);
       }


### PR DESCRIPTION
This dependency is not necessary so we can remove it