### PR TITLE
chore: Add TS type for `NodeFileTraceReasonType`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       branches: 80.5,
-      functions: 95.28,
+      functions: 95.2,
       lines: 85.87,
       statements: -249
     }

--- a/prepare-install.js
+++ b/prepare-install.js
@@ -14,6 +14,7 @@ if (isWin) {
   unlinkSync(join(__dirname, 'test', 'integration', 'highlights.js'));
   unlinkSync(join(__dirname, 'test', 'integration', 'hot-shots.js'));
   unlinkSync(join(__dirname, 'test', 'integration', 'loopback.js'));
+  unlinkSync(join(__dirname, 'test', 'integration', 'playwright-core.js'));
   delete pkg.devDependencies['@tensorflow/tfjs-node'];
   delete pkg.devDependencies['argon2'];
   delete pkg.devDependencies['highlights'];

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -1,4 +1,4 @@
-import { NodeFileTraceOptions, NodeFileTraceResult, NodeFileTraceReasons, Stats } from './types';
+import { NodeFileTraceOptions, NodeFileTraceResult, NodeFileTraceReasons, Stats, NodeFileTraceReasonType } from './types';
 import { basename, dirname, extname, relative, resolve, sep } from 'path';
 import fs from 'graceful-fs';
 import analyze, { AnalyzeResult } from './analyze';
@@ -243,7 +243,7 @@ export class Job {
     return join(await this.realpath(dirname(path), parent, seen), basename(path));
   }
 
-  async emitFile (path: string, reason: string, parent?: string, isRealpath = false) {
+  async emitFile (path: string, reasonType: NodeFileTraceReasonType, parent?: string, isRealpath = false) {
     if (!isRealpath) {
       path = await this.realpath(path, parent);
     }
@@ -256,7 +256,7 @@ export class Job {
     
     if (!reasonEntry) {
       reasonEntry = {
-        type: reason,
+        type: reasonType,
         ignored: false,
         parents: new Set()
       };

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,7 +51,7 @@ export interface NodeFileTraceOptions {
   resolve?: (id: string, parent: string, job: Job, cjsResolve: boolean) => Promise<string | string[]>;
 }
 
-export type NodeFileTraceReasonType = 'initial' | 'resolve' | 'dependency' | 'asset'
+export type NodeFileTraceReasonType = 'initial' | 'resolve' | 'dependency' | 'asset' | 'sharedlib';
 
 export interface NodeFileTraceReasons extends Map<string, {
   type: NodeFileTraceReasonType;

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,8 +51,10 @@ export interface NodeFileTraceOptions {
   resolve?: (id: string, parent: string, job: Job, cjsResolve: boolean) => Promise<string | string[]>;
 }
 
+export type NodeFileTraceReasonType = 'initial' | 'resolve' | 'dependency' | 'asset'
+
 export interface NodeFileTraceReasons extends Map<string, {
-  type: string;
+  type: NodeFileTraceReasonType;
   ignored: boolean;
   parents: Set<string>;
 }> {}


### PR DESCRIPTION
Adds a type to enumerate all possible reasons