### PR TITLE
major: Change reason type from string to array

### DIFF
--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -256,11 +256,13 @@ export class Job {
     
     if (!reasonEntry) {
       reasonEntry = {
-        type: reasonType,
+        type: [reasonType],
         ignored: false,
         parents: new Set()
       };
       this.reasons.set(path, reasonEntry)
+    } else if (!reasonEntry.type.includes(reasonType)) {
+      reasonEntry.type.push(reasonType)
     }
     if (parent && this.ignoreFn(path, parent)) {
       if (!this.fileList.has(path) && reasonEntry) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,7 +54,7 @@ export interface NodeFileTraceOptions {
 export type NodeFileTraceReasonType = 'initial' | 'resolve' | 'dependency' | 'asset' | 'sharedlib';
 
 export interface NodeFileTraceReasons extends Map<string, {
-  type: NodeFileTraceReasonType;
+  type: NodeFileTraceReasonType[];
   ignored: boolean;
   parents: Set<string>;
 }> {}

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -107,6 +107,7 @@ for (const { testName, isRoot } of unitTests) {
         const normalizeInputRoot = file =>
           isRoot ? join('./', unitPath, file) : join('test/unit', testName, file)
         
+        const getReasonType = file => reasons.get(normalizeInputRoot(file)).type
         
         expect([...collectFiles(normalizeInputRoot('input.js'))].map(normalizeFilesRoot).sort()).toEqual([
           "package.json",
@@ -136,17 +137,17 @@ for (const { testName, isRoot } of unitTests) {
           "test/unit/multi-input/style.module.css",
         ])
 
-        expect(reasons.get('test/unit/multi-input/input.js').type).toEqual(['initial', 'dependency'])
-        expect(reasons.get('test/unit/multi-input/input-2.js').type).toEqual(['initial', 'dependency'])
-        expect(reasons.get('test/unit/multi-input/input-3.js').type).toEqual(['initial', 'dependency'])
-        expect(reasons.get('test/unit/multi-input/input-4.js').type).toEqual(['initial', 'dependency'])
-        expect(reasons.get('test/unit/multi-input/child-1.js').type).toEqual(['dependency'])
-        expect(reasons.get('test/unit/multi-input/child-2.js').type).toEqual(['dependency'])
-        expect(reasons.get('test/unit/multi-input/child-3.js').type).toEqual(['dependency'])
-        expect(reasons.get('test/unit/multi-input/child-4.js').type).toEqual(['dependency'])
-        expect(reasons.get('test/unit/multi-input/asset.txt').type).toEqual(['asset'])
-        expect(reasons.get('test/unit/multi-input/asset-2.txt').type).toEqual(['asset'])
-        expect(reasons.get('test/unit/multi-input/style.module.css').type).toEqual(['dependency', 'asset'])
+        expect(getReasonType('input.js')).toEqual(['initial', 'dependency'])
+        expect(getReasonType('input-2.js')).toEqual(['initial', 'dependency'])
+        expect(getReasonType('input-3.js')).toEqual(['initial', 'dependency'])
+        expect(getReasonType('input-4.js')).toEqual(['initial', 'dependency'])
+        expect(getReasonType('child-1.js')).toEqual(['dependency'])
+        expect(getReasonType('child-2.js')).toEqual(['dependency'])
+        expect(getReasonType('child-3.js')).toEqual(['dependency'])
+        expect(getReasonType('child-4.js')).toEqual(['dependency'])
+        expect(getReasonType('asset.txt')).toEqual(['asset'])
+        expect(getReasonType('asset-2.txt')).toEqual(['asset'])
+        expect(getReasonType('style.module.css')).toEqual(['dependency', 'asset'])
 
       }
       

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -59,7 +59,7 @@ for (const { testName, isRoot } of unitTests) {
       }
       
       if (testName === 'multi-input') {
-        inputFileNames.push('input-2.js', 'input-3.js')
+        inputFileNames.push('input-2.js', 'input-3.js', 'input-4.js');
       }
       
       const { fileList, reasons } = await nodeFileTrace(
@@ -129,6 +129,25 @@ for (const { testName, isRoot } of unitTests) {
           "test/unit/multi-input/asset.txt",
           "test/unit/multi-input/child-3.js",
         ])
+
+        expect([...collectFiles(normalizeInputRoot('input-4.js'))].map(normalizeFilesRoot).sort()).toEqual([
+          "package.json",
+          "test/unit/multi-input/child-4.js",
+          "test/unit/multi-input/style.module.css",
+        ])
+
+        expect(reasons.get('test/unit/multi-input/input.js').type).toEqual(['initial', 'dependency'])
+        expect(reasons.get('test/unit/multi-input/input-2.js').type).toEqual(['initial', 'dependency'])
+        expect(reasons.get('test/unit/multi-input/input-3.js').type).toEqual(['initial', 'dependency'])
+        expect(reasons.get('test/unit/multi-input/input-4.js').type).toEqual(['initial', 'dependency'])
+        expect(reasons.get('test/unit/multi-input/child-1.js').type).toEqual(['dependency'])
+        expect(reasons.get('test/unit/multi-input/child-2.js').type).toEqual(['dependency'])
+        expect(reasons.get('test/unit/multi-input/child-3.js').type).toEqual(['dependency'])
+        expect(reasons.get('test/unit/multi-input/child-4.js').type).toEqual(['dependency'])
+        expect(reasons.get('test/unit/multi-input/asset.txt').type).toEqual(['asset'])
+        expect(reasons.get('test/unit/multi-input/asset-2.txt').type).toEqual(['asset'])
+        expect(reasons.get('test/unit/multi-input/style.module.css').type).toEqual(['dependency', 'asset'])
+
       }
       
       let expected;

--- a/test/unit/multi-input/child-4.js
+++ b/test/unit/multi-input/child-4.js
@@ -1,0 +1,4 @@
+const fs = require('fs')
+const { join } = require('path')
+
+fs.readFileSync(join(__dirname, 'style.module.css'))

--- a/test/unit/multi-input/input-4.js
+++ b/test/unit/multi-input/input-4.js
@@ -1,0 +1,3 @@
+import style from './style.module.css';
+
+import child4 from './child-4';

--- a/test/unit/multi-input/output.js
+++ b/test/unit/multi-input/output.js
@@ -5,7 +5,10 @@
   "test/unit/multi-input/child-1.js",
   "test/unit/multi-input/child-2.js",
   "test/unit/multi-input/child-3.js",
+  "test/unit/multi-input/child-4.js",
   "test/unit/multi-input/input-2.js",
   "test/unit/multi-input/input-3.js",
-  "test/unit/multi-input/input.js"
+  "test/unit/multi-input/input-4.js",
+  "test/unit/multi-input/input.js",
+  "test/unit/multi-input/style.module.css"
 ]

--- a/test/unit/multi-input/style.module.css
+++ b/test/unit/multi-input/style.module.css
@@ -1,0 +1,1 @@
+body { color: green; }


### PR DESCRIPTION
There is a scenario where a single file is both imported as a `dependency` and read as a `asset` file so we must keep track of both usages in the Reason object.