### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -219,8 +219,8 @@ export default async function analyze(id: string, code: string, job: Job): Promi
     if (!job.analysis.emitGlobs) return;
     const wildcardIndex = wildcardPath.indexOf(WILDCARD);
     const dirIndex = wildcardIndex === -1 ? wildcardPath.length : wildcardPath.lastIndexOf(path.sep, wildcardIndex);
-    const assetDirPath = wildcardPath.substr(0, dirIndex);
-    const patternPath = wildcardPath.substr(dirIndex);
+    const assetDirPath = wildcardPath.substring(0, dirIndex);
+    const patternPath = wildcardPath.slice(dirIndex);
     const wildcardPattern = patternPath.replace(wildcardRegEx, (_match, index) => {
       return patternPath[index - 1] === path.sep ? '**/*' : '*';
     }).replace(repeatGlobRegEx, '/**/*') || '/**/*';
@@ -389,8 +389,8 @@ export default async function analyze(id: string, code: string, job: Job): Promi
 
     const wildcardIndex = wildcardRequire.indexOf(WILDCARD);
     const dirIndex = wildcardIndex === -1 ? wildcardRequire.length : wildcardRequire.lastIndexOf(path.sep, wildcardIndex);
-    const wildcardDirPath = wildcardRequire.substr(0, dirIndex);
-    const patternPath = wildcardRequire.substr(dirIndex);
+    const wildcardDirPath = wildcardRequire.substring(0, dirIndex);
+    const patternPath = wildcardRequire.slice(dirIndex);
     let wildcardPattern = patternPath.replace(wildcardRegEx, (_match, index) => {
       return patternPath[index - 1] === path.sep ? '**/*' : '*';
     }) || '/**/*';
@@ -806,7 +806,7 @@ export default async function analyze(id: string, code: string, job: Job): Promi
     // verify the asset file / directory exists
     const wildcardIndex = assetPath.indexOf(WILDCARD);
     const dirIndex = wildcardIndex === -1 ? assetPath.length : assetPath.lastIndexOf(path.sep, wildcardIndex);
-    const basePath = assetPath.substr(0, dirIndex);
+    const basePath = assetPath.substring(0, dirIndex);
     try {
       var stats = await job.stat(basePath);
       if (stats === null) {
@@ -845,11 +845,11 @@ export default async function analyze(id: string, code: string, job: Job): Promi
     if (assetPath.endsWith(path.sep + 'node_modules' + wildcardSuffix))
       return false;
     // do not emit directories above __dirname
-    if (dir.startsWith(assetPath.substr(0, assetPath.length - wildcardSuffix.length) + path.sep))
+    if (dir.startsWith(assetPath.slice(0, assetPath.length - wildcardSuffix.length) + path.sep))
       return false;
     // do not emit asset directories higher than the node_modules base if a package
     if (pkgBase) {
-      const nodeModulesBase = id.substr(0, id.indexOf(path.sep + 'node_modules')) + path.sep + 'node_modules' + path.sep;
+      const nodeModulesBase = id.substring(0, id.indexOf(path.sep + 'node_modules')) + path.sep + 'node_modules' + path.sep;
       if (!assetPath.startsWith(nodeModulesBase)) {
         if (job.log) console.log('Skipping asset emission of ' + assetPath.replace(wildcardRegEx, '*') + ' for ' + id + ' as it is outside the package base ' + pkgBase);
         return false;

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -281,7 +281,7 @@ export class Job {
     const rootSeparatorIndex = path.indexOf(sep);
     let separatorIndex: number;
     while ((separatorIndex = path.lastIndexOf(sep)) > rootSeparatorIndex) {
-      path = path.substr(0, separatorIndex);
+      path = path.slice(0, separatorIndex);
       if (await this.isFile(path + sep + 'package.json'))
         return path;
     }
@@ -331,7 +331,7 @@ export class Job {
       ...[...assets].map(async asset => {
         const ext = extname(asset);
         if (ext === '.js' || ext === '.mjs' || ext === '.node' || ext === '' ||
-            this.ts && (ext === '.ts' || ext === '.tsx') && asset.startsWith(this.base) && asset.substr(this.base.length).indexOf(sep + 'node_modules' + sep) === -1)
+            this.ts && (ext === '.ts' || ext === '.tsx') && asset.startsWith(this.base) && asset.slice(this.base.length).indexOf(sep + 'node_modules' + sep) === -1)
           await this.emitDependency(asset, path);
         else
           await this.emitFile(asset, 'asset', path);

--- a/src/resolve-dependency.ts
+++ b/src/resolve-dependency.ts
@@ -38,8 +38,8 @@ async function resolveFile (path: string, parent: string, job: Job): Promise<str
   if (path.endsWith('/')) return undefined;
   path = await job.realpath(path, parent);
   if (await job.isFile(path)) return path;
-  if (job.ts && path.startsWith(job.base) && path.substr(job.base.length).indexOf(sep + 'node_modules' + sep) === -1 && await job.isFile(path + '.ts')) return path + '.ts';
-  if (job.ts && path.startsWith(job.base) && path.substr(job.base.length).indexOf(sep + 'node_modules' + sep) === -1 && await job.isFile(path + '.tsx')) return path + '.tsx';
+  if (job.ts && path.startsWith(job.base) && path.slice(job.base.length).indexOf(sep + 'node_modules' + sep) === -1 && await job.isFile(path + '.ts')) return path + '.ts';
+  if (job.ts && path.startsWith(job.base) && path.slice(job.base.length).indexOf(sep + 'node_modules' + sep) === -1 && await job.isFile(path + '.tsx')) return path + '.tsx';
   if (await job.isFile(path + '.js')) return path + '.js';
   if (await job.isFile(path + '.json')) return path + '.json';
   if (await job.isFile(path + '.node')) return path + '.node';
@@ -216,7 +216,7 @@ async function resolvePackage (name: string, parent: string, job: Job, cjsResolv
   let separatorIndex: number;
   const rootSeparatorIndex = packageParent.indexOf(sep);
   while ((separatorIndex = packageParent.lastIndexOf(sep)) > rootSeparatorIndex) {
-    packageParent = packageParent.substr(0, separatorIndex);
+    packageParent = packageParent.slice(0, separatorIndex);
     const nodeModulesDir = packageParent + sep + 'node_modules';
     const stat = await job.stat(nodeModulesDir);
     if (!stat || !stat.isDirectory()) continue;

--- a/src/utils/get-package-base.ts
+++ b/src/utils/get-package-base.ts
@@ -7,9 +7,9 @@ export function getPackageBase(id: string): string | undefined {
   if (pkgIndex !== -1 &&
       (id[pkgIndex - 1] === '/' || id[pkgIndex - 1] === '\\') &&
       (id[pkgIndex + 12] === '/' || id[pkgIndex + 12] === '\\')) {
-    const pkgNameMatch = id.substr(pkgIndex + 13).match(pkgNameRegEx);
+    const pkgNameMatch = id.slice(pkgIndex + 13).match(pkgNameRegEx);
     if (pkgNameMatch)
-      return id.substr(0, pkgIndex + 13 + pkgNameMatch[0].length);
+      return id.slice(0, pkgIndex + 13 + pkgNameMatch[0].length);
   }
   return undefined;
 }
@@ -19,7 +19,7 @@ export function getPackageName(id: string): string | undefined {
   if (pkgIndex !== -1 &&
       (id[pkgIndex - 1] === '/' || id[pkgIndex - 1] === '\\') &&
       (id[pkgIndex + 12] === '/' || id[pkgIndex + 12] === '\\')) {
-    const pkgNameMatch = id.substr(pkgIndex + 13).match(pkgNameRegEx);
+    const pkgNameMatch = id.slice(pkgIndex + 13).match(pkgNameRegEx);
     if (pkgNameMatch && pkgNameMatch.length > 0) {
       return pkgNameMatch[0].replace(/\\/g,  '/');
     }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) or [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) (if the second parameter could be negative) which works similarily but aren't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.
