### PR TITLE
feat: add `nft why` command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { join, dirname } from 'path';
+import { join, dirname, relative, isAbsolute } from 'path';
 import { promises, statSync, lstatSync } from 'graceful-fs';
 const { copyFile, mkdir } = promises;
 const rimraf = require('rimraf');
@@ -33,6 +33,7 @@ async function cli(
   ) {
   const opts = {
     ts: true,
+    base: cwd,
     mixedModules: true,
     log: action == 'print' || action == 'build',
   };
@@ -76,7 +77,11 @@ async function cli(
     if (!exitpoint) {
       throw new Error('Expected additional argument for "why" action');
     }
-    printStack(exitpoint, reasons, stdout, cwd)
+    const normalizedExitPoint = isAbsolute(exitpoint)
+      ? relative(cwd, exitpoint)
+      : exitpoint;
+
+    printStack(normalizedExitPoint, reasons, stdout, cwd);
   } else {
     stdout.push(`△ nft ${require('../package.json').version}`);
     stdout.push('');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { join, dirname, relative, isAbsolute } from 'path';
+import { join, dirname, relative, isAbsolute, sep } from 'path';
 import { promises, statSync, lstatSync } from 'graceful-fs';
 const { copyFile, mkdir } = promises;
 const rimraf = require('rimraf');
@@ -77,9 +77,9 @@ async function cli(
     if (!exitpoint) {
       throw new Error('Expected additional argument for "why" action');
     }
-    const normalizedExitPoint = isAbsolute(exitpoint)
+    const normalizedExitPoint = (isAbsolute(exitpoint)
       ? relative(cwd, exitpoint)
-      : exitpoint;
+      : exitpoint).replace(/[/\\]/g, sep);
 
     printStack(normalizedExitPoint, reasons, stdout, cwd);
   } else {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,8 +8,8 @@ import { nodeFileTrace } from './node-file-trace';
 import { NodeFileTraceReasons } from './types';
 
 function printStack(file: string, reasons: NodeFileTraceReasons, stdout: string[], cwd: string) {
-  stdout.push(file.slice(cwd.length))
-  const reason = reasons.get(file)
+  stdout.push(file);
+  const reason = reasons.get(file);
 
   if (
     !reason ||
@@ -20,7 +20,7 @@ function printStack(file: string, reasons: NodeFileTraceReasons, stdout: string[
   }
  
   for (let parent of reason.parents) {
-    printStack(parent, reasons, stdout, cwd)
+    printStack(parent, reasons, stdout, cwd);
   }
 }
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,6 +1,6 @@
 const { promisify } = require('util');
 const { existsSync } = require('fs');
-const { join, dirname } = require('path');
+const { join } = require('path');
 const cp = require('child_process');
 const exec = promisify(cp.exec);
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -47,7 +47,7 @@ it('should correctly show why from cli', async () => {
   if (stderr) {
     throw new Error(stderr);
   }
-  expect(stdout).toMatch('unit/wildcard/assets/asset1.txt\nunit/wildcard/input.js');
+  expect(stdout.replace(/\\/g, '/')).toMatch('unit/wildcard/assets/asset1.txt\nunit/wildcard/input.js');
 });
 
 it('should correctly print help when unknown action is used', async () => {
@@ -90,7 +90,7 @@ it('[codecov] should correctly show why from required cli', async () => {
   const exitpoint = join(__dirname, outputjs);
   const cwd = __dirname;
   const stdout = await cli('why', entrypoint, exitpoint, 'dist', cwd);
-  expect(stdout).toMatch('unit/wildcard/assets/asset1.txt\nunit/wildcard/input.js');
+  expect(stdout.replace(/\\/g, '/')).toMatch('unit/wildcard/assets/asset1.txt\nunit/wildcard/input.js');
 });
 
 it('[codecov] should correctly print help when unknown action is used', async () => {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,6 +1,6 @@
 const { promisify } = require('util');
 const { existsSync } = require('fs');
-const { join } = require('path');
+const { join, dirname } = require('path');
 const cp = require('child_process');
 const exec = promisify(cp.exec);
 
@@ -42,6 +42,14 @@ it('should correctly show size from cli', async () => {
   expect(stdout).toMatch('bytes total');
 });
 
+it('should correctly show why from cli', async () => {
+  const { stderr, stdout } = await exec(`node ../out/cli.js why ${inputjs} ${outputjs}`, { cwd: __dirname });
+  if (stderr) {
+    throw new Error(stderr);
+  }
+  expect(stdout).toMatch('unit/wildcard/assets/asset1.txt\nunit/wildcard/input.js');
+});
+
 it('should correctly print help when unknown action is used', async () => {
   const { stderr, stdout } = await exec(`node ../out/cli.js unknown ${inputjs}`, { cwd: __dirname });
   if (stderr) {
@@ -53,7 +61,7 @@ it('should correctly print help when unknown action is used', async () => {
 it('[codecov] should correctly print trace from required cli', async () => {
   // This test is only here to satisfy code coverage
   const cli = require('../out/cli.js')
-  const files = [join(__dirname, inputjs)];
+  const files = join(__dirname, inputjs);
   const stdout = await cli('print', files);
   expect(stdout).toMatch(normalizeOutput(outputjs));
 });
@@ -61,7 +69,7 @@ it('[codecov] should correctly print trace from required cli', async () => {
 it('[codecov] should correctly build dist from required cli', async () => {
   // This test is only here to satisfy code coverage
   const cli = require('../out/cli.js')
-  const files = [join(__dirname, inputjs)];
+  const files = join(__dirname, inputjs);
   await cli('build', files);
   const found = existsSync(join(__dirname, outputjs));
   expect(found).toBe(true);
@@ -70,15 +78,25 @@ it('[codecov] should correctly build dist from required cli', async () => {
 it('[codecov] should correctly show size in bytes from required cli', async () => {
   // This test is only here to satisfy code coverage
   const cli = require('../out/cli.js')
-  const files = [join(__dirname, inputjs)];
+  const files = join(__dirname, inputjs);
   const stdout = await cli('size', files);
   expect(stdout).toMatch('bytes total');
+});
+
+it('[codecov] should correctly show why from required cli', async () => {
+  // This test is only here to satisfy code coverage
+  const cli = require('../out/cli.js')
+  const entrypoint = join(__dirname, inputjs);
+  const exitpoint = join(__dirname, outputjs);
+  const cwd = __dirname;
+  const stdout = await cli('why', entrypoint, exitpoint, 'dist', cwd);
+  expect(stdout).toMatch('/unit/wildcard/assets/asset1.txt\n/unit/wildcard/input.js');
 });
 
 it('[codecov] should correctly print help when unknown action is used', async () => {
   // This test is only here to satisfy code coverage
   const cli = require('../out/cli.js')
-  const files = [join(__dirname, inputjs)];
+  const files = join(__dirname, inputjs);
   const stdout = await cli('unknown', files);
   expect(stdout).toMatch('$ nft [command] <file>');
 });

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -90,7 +90,7 @@ it('[codecov] should correctly show why from required cli', async () => {
   const exitpoint = join(__dirname, outputjs);
   const cwd = __dirname;
   const stdout = await cli('why', entrypoint, exitpoint, 'dist', cwd);
-  expect(stdout).toMatch('/unit/wildcard/assets/asset1.txt\n/unit/wildcard/input.js');
+  expect(stdout).toMatch('unit/wildcard/assets/asset1.txt\nunit/wildcard/input.js');
 });
 
 it('[codecov] should correctly print help when unknown action is used', async () => {


### PR DESCRIPTION
This PR adds a new command, `nft why`, to the cli that will print the reason why a file was included (similar to `yarn why`)