### PR TITLE
feat: allow all file extension inputs (including `.jsx`)

### DIFF
--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -33,10 +33,7 @@ export async function nodeFileTrace(files: string[], opts: NodeFileTraceOptions 
   await Promise.all(files.map(async file => {
     const path = resolve(file);
     await job.emitFile(path, 'initial');
-    if (path.endsWith('.js') || path.endsWith('.cjs') || path.endsWith('.mjs') || path.endsWith('.node') || job.ts && (path.endsWith('.ts') || path.endsWith('.tsx'))) {
-      return job.emitDependency(path);
-    }
-    return undefined;
+    return job.emitDependency(path);
   }));
 
   const result: NodeFileTraceResult = {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -50,6 +50,9 @@ for (const { testName, isRoot } of unitTests) {
       let inputFileNames = ["input.js"];
       let outputFileName = "output.js";
       
+      if (testName === "jsx-input") {
+        inputFileNames = ["input.jsx"];
+      }
       if (testName === "tsx-input") {
         inputFileNames = ["input.tsx"];
       }

--- a/test/unit/jsx-input/dep.jsx
+++ b/test/unit/jsx-input/dep.jsx
@@ -1,0 +1,1 @@
+export const dep = <h1>dep</h1>

--- a/test/unit/jsx-input/input.jsx
+++ b/test/unit/jsx-input/input.jsx
@@ -1,0 +1,3 @@
+import { readFileSync } from 'fs';
+
+readFileSync(__dirname + '/dep.jsx');

--- a/test/unit/jsx-input/output.js
+++ b/test/unit/jsx-input/output.js
@@ -1,0 +1,4 @@
+[
+  "test/unit/jsx-input/dep.jsx",
+  "test/unit/jsx-input/input.jsx"
+]


### PR DESCRIPTION
This fixes an issue where a file input ending with `.jsx` was not traced properly.

Since we already fail gracefully for files that cannot be parsed, this PR removes the guard on all input file extensions.

- Also fixes #249 