### PR TITLE
chore: windows tests should preserve yarn.lock

### DIFF
--- a/prepare-install.js
+++ b/prepare-install.js
@@ -7,7 +7,7 @@ if (isWin) {
   const pkgJson = readFileSync(join(__dirname, 'package.json'), 'utf8');
   const pkg = JSON.parse(pkgJson);
 
-  unlinkSync(join(__dirname, 'yarn.lock'));
+  //unlinkSync(join(__dirname, 'yarn.lock'));
   // Delete the integration tests that will never work in Windows
   unlinkSync(join(__dirname, 'test', 'integration', 'tensorflow.js'));
   unlinkSync(join(__dirname, 'test', 'integration', 'argon2.js'));


### PR DESCRIPTION
Windows tests should preserve yarn.lock

In the future we might want to use `--frozen-lockfile` but for now this will prevent windows tests from inadvertently upgrading dependencies.