### PR TITLE
fix: add concurrency limit to fs calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@mapbox/node-pre-gyp": "^1.0.5",
     "acorn": "^8.6.0",
+    "async-sema": "^3.1.1",
     "bindings": "^1.4.0",
     "estree-walker": "2.0.2",
     "glob": "^7.1.3",

--- a/readme.md
+++ b/readme.md
@@ -118,6 +118,18 @@ By its nature of integrating into existing build systems, the TypeScript
 compiler is not included in this project - rather the TypeScript transform
 layer requires separate integration into the `readFile` hook.
 
+#### File IO Concurrency
+
+In some large projects, the file tracing logic may process many files at the same time. In this case, if you do not limit the number of concurrent files IO, OOM problems are likely to occur.
+
+We use a default of 1024 concurrency to balance performance and memory usage for fs operations. You can increase this value to a higher number if you need to.
+
+```js
+const { fileList } = await nodeFileTrace(files, {
+  fileIOConcurrency: 2048,
+});
+```
+
 #### Analysis
 
 Analysis options allow customizing how much analysis should be performed to exactly work out the dependency list.

--- a/readme.md
+++ b/readme.md
@@ -122,7 +122,7 @@ layer requires separate integration into the `readFile` hook.
 
 In some large projects, the file tracing logic may process many files at the same time. In this case, if you do not limit the number of concurrent files IO, OOM problems are likely to occur.
 
-We use a default of 1024 concurrency to balance performance and memory usage for fs operations. You can increase this value to a higher number if you need to.
+We use a default of 1024 concurrency to balance performance and memory usage for fs operations. You can increase this value to a higher number for faster speed, but be aware of the memory issues if the concurrency is too high.
 
 ```js
 const { fileList } = await nodeFileTrace(files, {

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -81,8 +81,8 @@ export class Job {
     ts = true,
     analysis = {},
     cache,
-    // 1024 may enough here, to prevent memory issues cause by too many concurrent file IO
-    // and do not hurt the performance much
+    // we use a default of 1024 concurrency to balance
+    // performance and memory usage for fs operations
     fileIOConcurrency = Number(process.env.FILE_IO_CONCURRENCY) || 1024,
   }: NodeFileTraceOptions) {
     this.ts = ts;

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export interface NodeFileTraceOptions {
   stat?: (path: string) => Promise<Stats | null>;
   readlink?: (path: string) => Promise<string | null>;
   resolve?: (id: string, parent: string, job: Job, cjsResolve: boolean) => Promise<string | string[]>;
+  fileIOConcurrency?: number;
 }
 
 export type NodeFileTraceReasonType = 'initial' | 'resolve' | 'dependency' | 'asset' | 'sharedlib';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3047,6 +3047,11 @@ async-retry@^1.2.1, async-retry@^1.3.1:
   dependencies:
     retry "0.12.0"
 
+async-sema@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/async-sema/-/async-sema-3.1.1.tgz#e527c08758a0f8f6f9f15f799a173ff3c40ea808"
+  integrity sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==
+
 async@0.9.x:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"


### PR DESCRIPTION
This adds concurrency limits to our `fs` calls to attempt to alleviate memory issues with too many promises being stored in memory at once. 

x-ref: [slack thread](https://vercel.slack.com/archives/CGU8HUTUH/p1657905624763969?thread_ts=1655847330.113019&cid=CGU8HUTUH)