### PR TITLE
fix: bump rollup pluginutils version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   ],
   "dependencies": {
     "@mapbox/node-pre-gyp": "^1.0.5",
+    "@rollup/pluginutils": "^4.0.0",
     "acorn": "^8.6.0",
     "async-sema": "^3.1.1",
     "bindings": "^1.4.0",
@@ -28,8 +29,7 @@
     "graceful-fs": "^4.2.9",
     "micromatch": "^4.0.2",
     "node-gyp-build": "^4.2.2",
-    "resolve-from": "^5.0.0",
-    "rollup-pluginutils": "^2.8.2"
+    "resolve-from": "^5.0.0"
   },
   "devDependencies": {
     "@azure/cosmos": "^2.1.7",

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -1,6 +1,6 @@
 import path from 'path';
-import { WalkerContext, Node } from 'estree-walker';
-import { attachScopes } from 'rollup-pluginutils';
+import { AsyncHandler, asyncWalk } from 'estree-walker';
+import { attachScopes } from '@rollup/pluginutils';
 import { evaluate, UNKNOWN, FUNCTION, WILDCARD, wildcardRegEx } from './utils/static-eval';
 import { Parser } from 'acorn';
 import bindings from 'bindings';
@@ -10,6 +10,7 @@ import { getPackageBase } from './utils/get-package-base';
 import { pregyp, nbind } from './utils/binary-locators';
 import { normalizeDefaultRequire, normalizeWildcardRequire } from './utils/interop-require';
 import handleSpecialCases from './utils/special-cases';
+import { Node } from './utils/types';
 import resolve from './resolve-dependency.js';
 //@ts-ignore
 import nodeGypBuild from 'node-gyp-build';
@@ -17,11 +18,6 @@ import nodeGypBuild from 'node-gyp-build';
 import mapboxPregyp from '@mapbox/node-pre-gyp';
 import { Job } from './node-file-trace';
 import { fileURLToPath, pathToFileURL, URL } from 'url';
-
-
-// TypeScript fails to resolve estree-walker to the top due to the conflicting
-// estree-walker version in rollup-pluginutils so we use require here instead
-const asyncWalk: typeof import('../node_modules/estree-walker').asyncWalk = require('estree-walker').asyncWalk
 
 // Note: these should be deprecated over time as they ship in Acorn core
 const acorn = Parser.extend(
@@ -468,7 +464,7 @@ export default async function analyze(id: string, code: string, job: Job): Promi
     handleWrappers(ast);
     await handleSpecialCases({ id, ast, emitDependency: path => deps.add(path), emitAsset: path => assets.add(path), emitAssetDirectory, job });
   }
-  async function backtrack (parent: Node, context?: WalkerContext) {
+  async function backtrack (parent: Node, context?: ThisParameterType<AsyncHandler>) {
     // computing a static expression outward
     // -> compute and backtrack
     // Note that `context` can be undefined in `leave()`

--- a/src/utils/ast-helpers.ts
+++ b/src/utils/ast-helpers.ts
@@ -1,4 +1,4 @@
-import { Node } from 'estree-walker';
+import { Node } from './types';
 
 export function isIdentifierRead(node: Node, parent: Node) {
   switch (parent.type) {

--- a/src/utils/static-eval.ts
+++ b/src/utils/static-eval.ts
@@ -1,5 +1,4 @@
-import { Node } from 'estree-walker';
-import { EvaluatedValue, StaticValue, ConditionalValue } from './types';
+import { EvaluatedValue, StaticValue, ConditionalValue, Node } from './types';
 import { URL } from 'url';
 type Walk = (node: Node) => EvaluatedValue;
 type State = { computeBranches: boolean, vars: Record<string, any> };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,16 +1,25 @@
 import { Node as ESTreeNode } from 'estree';
 export type Ast = { body: ESTreeNode[] };
 
-
 export interface StaticValue {
     value: any;
     wildcards?: string[];
-  }
+}
   
-  export interface ConditionalValue {
-    test: string;
-    then: any;
-    else: any;
-  }
-  
-  export type EvaluatedValue = StaticValue | ConditionalValue | undefined;
+export interface ConditionalValue {
+  test: string;
+  then: any;
+  else: any;
+}
+
+export type EvaluatedValue = StaticValue | ConditionalValue | undefined;
+
+/**
+ * A more lax version of the 'estree' Node type
+ */
+export interface Node {
+  start: number;
+  end: number;
+  type: string;
+  [propName: string]: any;
+}

--- a/src/utils/wrappers.ts
+++ b/src/utils/wrappers.ts
@@ -1,5 +1,5 @@
-import { walk, Node as ESNode } from 'estree-walker';
-import { Ast } from './types';
+import { walk } from 'estree-walker';
+import { Ast, Node as ESNode } from './types';
 import { SimpleCallExpression, Node, Literal, FunctionExpression, ReturnStatement, ObjectExpression, ArrayExpression, Property, CallExpression } from 'estree';
 
 function isUndefinedOrVoid (node: Node) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1744,6 +1744,14 @@
   resolved "https://registry.yarnpkg.com/@rdfjs/to-ntriples/-/to-ntriples-1.0.2.tgz#c2fe8f6e8d8010c2315c0a816d1cd42a4447965e"
   integrity sha512-ngw5XAaGHjgGiwWWBPGlfdCclHftonmbje5lMys4G2j4NvfExraPIuRZgjSnd5lg4dnulRVUll8tRbgKO+7EDA==
 
+"@rollup/pluginutils@^4.0.0":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.2.1.tgz#e6c6c3aba0744edce3fb2074922d3776c0af2a6d"
+  integrity sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==
+  dependencies:
+    estree-walker "^2.0.1"
+    picomatch "^2.2.2"
+
 "@segment/loosely-validate-event@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz#87dfc979e5b4e7b82c5f1d8b722dfd5d77644681"
@@ -5959,15 +5967,10 @@ estree-is-function@^1.0.0:
   resolved "https://registry.yarnpkg.com/estree-is-function/-/estree-is-function-1.0.0.tgz#c0adc29806d7f18a74db7df0f3b2666702e37ad2"
   integrity sha512-nSCWn1jkSq2QAtkaVLJZY2ezwcFO161HVc174zL1KPW3RJ+O6C3eJb8Nx7OXzvhoEv+nLgSR1g71oWUHUDTrJA==
 
-estree-walker@2.0.2:
+estree-walker@2.0.2, estree-walker@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
-
-estree-walker@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
-  integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -12481,6 +12484,11 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
+picomatch@^2.2.2:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
 picomatch@^2.2.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
@@ -13814,13 +13822,6 @@ robots-parser@^2.0.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/robots-parser/-/robots-parser-2.3.0.tgz#d79e86e26e13fa0a806adbc37f4cf1b96aebc8c3"
   integrity sha512-RvuCITckrHM9k8DxCCU9rqWpuuKRfVX9iHG751dC3/EdERxp9gJATxYYdYOT3L0T+TAT4+27lENisk/VbHm47A==
-
-rollup-pluginutils@^2.8.2:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
-  integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
-  dependencies:
-    estree-walker "^0.6.1"
 
 rootpath@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
Part of #315

This fixes a bug where `attachScopes` didn't detect the new scope inside the for loop with shadowed variables before, resulting in later code paths possibly crashing because they expect the dependency to be of type string. No test added because as noted in #315 this doesn't thix that issue (if it even is one).

Bumping the version made a previous workaround of conflicting estree-walker versions unnecessary, but required to bring back a now-deleted type from the package