### PR TITLE
fix: Make caching work correctly in async context

### DIFF
--- a/src/fs.ts
+++ b/src/fs.ts
@@ -1,0 +1,116 @@
+import type { Stats } from "fs";
+import { resolve } from "path";
+import fs from "graceful-fs";
+import { Sema } from "async-sema";
+
+const fsReadFile = fs.promises.readFile;
+const fsReadlink = fs.promises.readlink;
+const fsStat = fs.promises.stat;
+
+export class CachedFileSystem {
+  private fileCache: Map<string, Promise<string | null>>;
+  private statCache: Map<string, Promise<Stats | null>>;
+  private symlinkCache: Map<string, Promise<string | null>>;
+  private fileIOQueue: Sema;
+
+  constructor({
+    cache,
+    fileIOConcurrency,
+  }: {
+    cache?: any;
+    fileIOConcurrency: number;
+  }) {
+    this.fileIOQueue = new Sema(fileIOConcurrency);
+    this.fileCache = (cache && cache.fileCache) || new Map();
+    this.statCache = (cache && cache.statCache) || new Map();
+    this.symlinkCache = (cache && cache.symlinkCache) || new Map();
+
+    if (cache) {
+      cache.fileCache = this.fileCache;
+      cache.statCache = this.statCache;
+      cache.symlinkCache = this.symlinkCache;
+    }
+  }
+
+  async readlink(path: string): Promise<string | null> {
+    const cached = this.symlinkCache.get(path);
+    if (cached !== undefined) return cached;
+    // This is not awaiting the response, so that the cache is instantly populated and
+    // future calls serve the Promise from the cache
+    const readlinkPromise = this.executeFileIO(path, this._internalReadlink);
+    this.symlinkCache.set(path, readlinkPromise);
+
+    return readlinkPromise;
+  }
+
+  async readFile(path: string): Promise<string | null> {
+    const cached = this.fileCache.get(path);
+    if (cached !== undefined) return cached;
+    // This is not awaiting the response, so that the cache is instantly populated and
+    // future calls serve the Promise from the cache
+    const readFilePromise = this.executeFileIO(path, this._internalReadFile);
+    this.fileCache.set(path, readFilePromise);
+
+    return readFilePromise;
+  }
+
+  async stat(path: string): Promise<Stats | null> {
+    const cached = this.statCache.get(path);
+    if (cached !== undefined) return cached;
+    // This is not awaiting the response, so that the cache is instantly populated and
+    // future calls serve the Promise from the cache
+    const statPromise = this.executeFileIO(path, this._internalStat);
+    this.statCache.set(path, statPromise);
+
+    return statPromise;
+  }
+
+  private async _internalReadlink(path: string) {
+    try {
+      const link = await fsReadlink(path);
+      // also copy stat cache to symlink
+      const stats = this.statCache.get(path);
+      if (stats) this.statCache.set(resolve(path, link), stats);
+      return link;
+    } catch (e: any) {
+      if (e.code !== "EINVAL" && e.code !== "ENOENT" && e.code !== "UNKNOWN")
+        throw e;
+      return null;
+    }
+  }
+
+  private async _internalReadFile(path: string): Promise<string | null> {
+    try {
+      return (await fsReadFile(path)).toString();
+    } catch (e: any) {
+      if (e.code === "ENOENT" || e.code === "EISDIR") {
+        return null;
+      }
+      throw e;
+    }
+  }
+
+  private async _internalStat(path: string) {
+    try {
+      return await fsStat(path);
+    } catch (e: any) {
+      if (e.code === "ENOENT") {
+        return null;
+      }
+      throw e;
+    }
+  }
+
+  private async executeFileIO<Return>(
+    path: string,
+    fileIO: (path: string) => Promise<Return>
+  ): Promise<Return> {
+    await this.fileIOQueue.acquire();
+
+    try {
+      return fileIO.call(this, path);
+    } finally {
+      this.fileIOQueue.release();
+    }
+  }
+}

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -21,9 +21,9 @@ export class CachedFileSystem {
     fileIOConcurrency: number;
   }) {
     this.fileIOQueue = new Sema(fileIOConcurrency);
-    this.fileCache = (cache && cache.fileCache) || new Map();
-    this.statCache = (cache && cache.statCache) || new Map();
-    this.symlinkCache = (cache && cache.symlinkCache) || new Map();
+    this.fileCache = cache?.fileCache ?? new Map();
+    this.statCache = cache?.statCache ?? new Map();
+    this.symlinkCache = cache?.symlinkCache ?? new Map();
 
     if (cache) {
       cache.fileCache = this.fileCache;

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -17,7 +17,7 @@ export class CachedFileSystem {
     cache,
     fileIOConcurrency,
   }: {
-    cache?: any;
+    cache?: { fileCache?: Map<string, Promise<string | null>>, statCache?: Map<string, Promise<Stats | null>>, symlinkCache?: Map<string, Promise<string | null>> };
     fileIOConcurrency: number;
   }) {
     this.fileIOQueue = new Sema(fileIOConcurrency);

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -1,6 +1,12 @@
 const fs = require('fs');
 const { join, relative } = require('path');
 const { nodeFileTrace } = require('../out/node-file-trace');
+const gracefulFS = require('graceful-fs');
+const analyze = require('../out/analyze.js').default;
+
+const stat = gracefulFS.promises.stat
+const readlink = gracefulFS.promises.readlink
+const readFile = gracefulFS.promises.readFile
 
 global._unit = true;
 
@@ -11,6 +17,38 @@ const unitTests = [
   ...unitTestDirs.map(testName => ({testName, isRoot: true})),
 ];
 
+jest.mock('../out/analyze.js', () => {
+  const originalModule = jest.requireActual('../out/analyze.js').default;
+
+  return {
+    __esModule: true,
+    default: jest.fn(originalModule)
+  };
+});
+
+jest.mock('graceful-fs', () => {
+  const originalModule = jest.requireActual('graceful-fs');
+
+  return {
+    ...originalModule,
+    promises: {
+      ...originalModule.promises,
+      stat: jest.fn(originalModule.promises.stat),
+      readFile: jest.fn(originalModule.promises.readFile),
+      readlink: jest.fn( originalModule.promises.readlink),
+    }
+  };
+});
+
+function resetFileIOMocks() {
+  analyze.mockClear();
+  stat.mockClear()
+  readFile.mockClear()
+  readlink.mockClear()
+}
+
+afterEach(resetFileIOMocks)
+
 for (const { testName, isRoot } of unitTests) {
   const testSuffix = `${testName} from ${isRoot ? 'root' : 'cwd'}`;
   if (process.platform === 'win32' && (isRoot || skipOnWindows.includes(testName))) {
@@ -18,7 +56,7 @@ for (const { testName, isRoot } of unitTests) {
     continue;
   };
   const unitPath = join(__dirname, 'unit', testName);
-  
+
   it(`should correctly trace ${testSuffix}`, async () => {
 
     // We mock readFile because when node-file-trace is integrated into @now/node
@@ -27,12 +65,12 @@ for (const { testName, isRoot } of unitTests) {
     // used in the tsx-input test:
     const readFileMock = jest.fn(function() {
       const [id] = arguments;
-      
+
       if (id.startsWith('custom-resolution-')) {
         return ''
       }
-      
-      // ensure sync readFile works as expected since default is 
+
+      // ensure sync readFile works as expected since default is
       // async now
       if (testName === 'wildcard') {
         try {
@@ -45,11 +83,11 @@ for (const { testName, isRoot } of unitTests) {
     });
 
     const nftCache = {}
-    
+
     const doTrace = async (cached = false) => {
       let inputFileNames = ["input.js"];
       let outputFileName = "output.js";
-      
+
       if (testName === "jsx-input") {
         inputFileNames = ["input.jsx"];
       }
@@ -63,13 +101,13 @@ for (const { testName, isRoot } of unitTests) {
         inputFileNames = ["input-cached.js"]
         outputFileName = "output-cached.js"
       }
-      
+
       if (testName === 'multi-input') {
         inputFileNames.push('input-2.js', 'input-3.js', 'input-4.js');
       }
-      
+
       const { fileList, reasons } = await nodeFileTrace(
-        inputFileNames.map(file => join(unitPath, file)), 
+        inputFileNames.map(file => join(unitPath, file)),
         {
           base: isRoot ? '/' : `${__dirname}/../`,
           processCwd: unitPath,
@@ -93,20 +131,20 @@ for (const { testName, isRoot } of unitTests) {
         }
       );
 
-      const normalizeFilesRoot = f => 
+      const normalizeFilesRoot = f =>
         (isRoot ? relative(join('./', __dirname, '..'), f) : f).replace(/\\/g, '/');
-      
+
       const normalizeInputRoot = f =>
         isRoot ? join('./', unitPath, f) : join('test/unit', testName, f);
-      
+
       const getReasonType = f => reasons.get(normalizeInputRoot(f)).type;
-      
+
       if (testName === 'multi-input') {
         const collectFiles = (parent, files = new Set()) => {
           fileList.forEach(file => {
             if (files.has(file)) return
             const reason = reasons.get(file)
-        
+
             if (reason.parents && reason.parents.has(parent)) {
               files.add(file)
               collectFiles(file, files)
@@ -114,7 +152,7 @@ for (const { testName, isRoot } of unitTests) {
           })
           return files
         }
-        
+
         expect([...collectFiles(normalizeInputRoot('input.js'))].map(normalizeFilesRoot).sort()).toEqual([
           "package.json",
           "test/unit/multi-input/asset-2.txt",
@@ -156,7 +194,7 @@ for (const { testName, isRoot } of unitTests) {
         expect(getReasonType('style.module.css')).toEqual(['dependency', 'asset'])
       }
       let sortedFileList = [...fileList].sort()
-      
+
       if (testName === 'microtime-node-gyp') {
         let foundMatchingBinary = false
         sortedFileList = sortedFileList.filter(file => {
@@ -169,9 +207,9 @@ for (const { testName, isRoot } of unitTests) {
           }
           return true
         })
-        expect(foundMatchingBinary).toBe(true) 
+        expect(foundMatchingBinary).toBe(true)
       }
-      
+
       let expected;
       try {
         expected = JSON.parse(fs.readFileSync(join(unitPath, outputFileName)).toString());
@@ -197,6 +235,26 @@ for (const { testName, isRoot } of unitTests) {
         fs.writeFileSync(join(unitPath, 'actual.js'), JSON.stringify(sortedFileList, null, 2));
         throw e;
       }
+
+      if (cached) {
+        // Everything should be cached in the second run, except for `processed-dependency` which adds 1 new input file
+        expect(stat).toHaveBeenCalledTimes(0);
+        expect(readlink).toHaveBeenCalledTimes(testName === 'processed-dependency' ? 1 : 0);
+        expect(readFile).toHaveBeenCalledTimes(testName === 'processed-dependency' ? 1 : 0);
+        expect(analyze).toHaveBeenCalledTimes(testName === 'processed-dependency' ? 1 : 0);
+      } else {
+        // Ensure all cached calls are only called once per file. The expected count is the count of calls unique per path
+        const uniqueStatCalls = new Set(stat.mock.calls.map((call) => call[0]));
+        const uniqueReadlinkCalls = new Set(readlink.mock.calls.map((call) => call[0]));
+        const uniqueReadFileCalls = new Set(readFile.mock.calls.map((call) => call[0]));
+        const uniqueAnalyzeFileCalls = new Set(analyze.mock.calls.map((call) => call[0]));
+        expect(stat).toHaveBeenCalledTimes(uniqueStatCalls.size);
+        expect(readlink).toHaveBeenCalledTimes(uniqueReadlinkCalls.size);
+        expect(readFile).toHaveBeenCalledTimes(uniqueReadFileCalls.size);
+        expect(analyze).toHaveBeenCalledTimes(uniqueAnalyzeFileCalls.size);
+      }
+
+      resetFileIOMocks();
     }
     await doTrace()
     // test tracing again with a populated nftTrace
@@ -204,7 +262,7 @@ for (const { testName, isRoot } of unitTests) {
     expect(nftCache.statCache).toBeDefined()
     expect(nftCache.symlinkCache).toBeDefined()
     expect(nftCache.analysisCache).toBeDefined()
-    
+
     try {
       await doTrace(true)
     } catch (err) {


### PR DESCRIPTION
Right now the cache was only populated after the call to the fs API succeed, which in an async context was leading to multiple file IO or analyze tasks started for the same file at once. This is because both file IO are async and so until the fs call finished other calls for the same file can still come in.

To fix this I extracted all file IO calls into a separate class that wraps everything correctly and instead of caching the actual result, now a Promise is cached. So the cache now always needs to be awaited.

As the values in the cache change this is definitely a breaking change. Something like this:

```diff
const cache = {};
await nodeFileTrace([file], {
    cache,
);

-const cacheValue = cache.fileCache.get(file);
+const cacheValue = await cache.fileCache.get(file);
```

I know this is quite a big change, just let me know what you think and if I should change anything. :) 

In my personal example the number of calls to analyze went from ~2400 to ~1600 and the runtime from ~3s to ~2.7s (which includes other work than nft)