### PR TITLE
fix: set `publishConfig.access=public`

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,5 +134,8 @@
   },
   "engines": {
     "node": ">=14"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
Fixes an error during publish:

```
npm ERR! code E403
npm ERR! 403 403 Forbidden - PUT https://registry.npmjs.org/@vercel%2fnft - Two-factor authentication is required to publish this package but an automation token was specified
```

https://github.com/vercel/nft/actions/runs/3586279450/jobs/6035283995#step:10:494