### PR TITLE
fix(resolution): Fix resolution of querystringed imports in ESM files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out
 coverage
 test/**/dist
 test/**/actual.js
+test/unit/cjs-querystring/who?what?idk!.js

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -266,16 +266,12 @@ export class Job {
       return;
     }
 
-    if (Array.isArray(resolved)) {
-      for (const item of resolved) {
-        // ignore builtins
-        if (item.startsWith('node:')) return;
-        await this.analyzeAndEmitDependency(item, path, cjsResolve);
-      }
-    } else {
+    // For simplicity, force `resolved` to be an array
+    resolved = Array.isArray(resolved) ? resolved : [resolved];
+    for (const item of resolved) {
       // ignore builtins
-      if (resolved.startsWith('node:')) return;
-      await this.analyzeAndEmitDependency(resolved, path, cjsResolve);
+      if (item.startsWith('node:')) return;
+      await this.analyzeAndEmitDependency(item, path, cjsResolve);
     }
   }
 

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -248,12 +248,12 @@ export class Job {
     } catch (e1: any) {
       error = e1;
       try {
-        if (this.ts && dep.endsWith('.js') && e1 instanceof NotFoundError) {
+        if (this.ts && strippedDep.endsWith('.js') && e1 instanceof NotFoundError) {
           // TS with ESM relative import paths need full extensions
           // (we have to write import "./foo.js" instead of import "./foo")
           // See https://www.typescriptlang.org/docs/handbook/esm-node.html
-          const depTS = dep.slice(0, -3) + '.ts';
-          resolved = await this.resolve(depTS, path, this, cjsResolve);
+          const strippedDepTS = strippedDep.slice(0, -3) + '.ts';
+          resolved = await this.resolve(strippedDepTS + queryString, path, this, cjsResolve);
           error = undefined;
         }
       } catch (e2: any) {

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -370,7 +370,11 @@ export class Job {
     return this.analyzeAndEmitDependency(path, parent)
   }
 
-  private async analyzeAndEmitDependency(path: string, parent?: string, cjsResolve?: boolean) {
+  private async analyzeAndEmitDependency(rawPath: string, parent?: string, cjsResolve?: boolean) {
+
+    // Strip the querystring, if any. (Only affects ESM dependencies.)
+    const { path } = parseSpecifier(rawPath, cjsResolve)
+
     if (this.processed.has(path)) {
       if (parent) {
         await this.emitFile(path, 'dependency', parent)

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -268,12 +268,12 @@ export class Job {
       for (const item of resolved) {
         // ignore builtins
         if (item.startsWith('node:')) return;
-        await this.emitDependency(item, path);
+        await this.analyzeAndEmitDependency(item, path, cjsResolve);
       }
     } else {
       // ignore builtins
       if (resolved.startsWith('node:')) return;
-      await this.emitDependency(resolved, path);
+      await this.analyzeAndEmitDependency(resolved, path, cjsResolve);
     }
   }
 
@@ -367,6 +367,10 @@ export class Job {
   }
 
   async emitDependency (path: string, parent?: string) {
+    return this.analyzeAndEmitDependency(path, parent)
+  }
+
+  private async analyzeAndEmitDependency(path: string, parent?: string, cjsResolve?: boolean) {
     if (this.processed.has(path)) {
       if (parent) {
         await this.emitFile(path, 'dependency', parent)
@@ -417,7 +421,7 @@ export class Job {
         const ext = extname(asset);
         if (ext === '.js' || ext === '.mjs' || ext === '.node' || ext === '' ||
             this.ts && (ext === '.ts' || ext === '.tsx') && asset.startsWith(this.base) && asset.slice(this.base.length).indexOf(sep + 'node_modules' + sep) === -1)
-          await this.emitDependency(asset, path);
+          await this.analyzeAndEmitDependency(asset, path, !isESM);
         else
           await this.emitFile(asset, 'asset', path);
       }),

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -12,6 +12,30 @@ const fsReadFile = fs.promises.readFile;
 const fsReadlink = fs.promises.readlink;
 const fsStat = fs.promises.stat;
 
+type ParseSpecifierResult = {
+  path: string;
+  queryString: string | null
+}
+
+// Splits an ESM specifier into path and querystring (including the leading `?`). (If the specifier is CJS,
+// it is passed through untouched.)
+export function parseSpecifier(specifier: string, cjsResolve: boolean = true): ParseSpecifierResult {
+  let path = specifier;
+  let queryString = null;
+
+  if (!cjsResolve) {
+    // Regex which splits a specifier into path and querystring, inspired by that in `enhanced-resolve`
+    // https://github.com/webpack/enhanced-resolve/blob/157ed9bcc381857d979e56d2f20a5a17c6362bff/lib/util/identifier.js#L8
+    const match = /^(#?(?:\0.|[^?#\0])*)(\?(?:\0.|[^\0])*)?$/.exec(specifier);
+    if (match) {
+      path = match[1]
+      queryString = match[2]
+    }
+  }
+
+  return {path, queryString};
+}
+
 function inPath (path: string, parent: string) {
   const pathWithSep = join(parent, sep);
   return path.startsWith(pathWithSep) && path !== pathWithSep;

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -1,6 +1,5 @@
 import { NodeFileTraceOptions, NodeFileTraceResult, NodeFileTraceReasons, Stats, NodeFileTraceReasonType } from './types';
 import { basename, dirname, extname, relative, resolve, sep, join } from 'path';
-import * as url from 'url';
 import fs from 'graceful-fs';
 import analyze, { AnalyzeResult } from './analyze';
 import resolveDependency, { NotFoundError } from './resolve-dependency';
@@ -24,7 +23,7 @@ export function splitQueryStringFromSpecifier(specifier: string, cjsResolve: boo
   let queryString = null;
 
   if (!cjsResolve) {
-    const specifierUrl = url.parse(specifier);
+    const specifierUrl = new URL(specifier, "placeholder-protocol://");
     queryString = specifierUrl.search;
 
     if (specifierUrl.search) {

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -1,11 +1,11 @@
 import { NodeFileTraceOptions, NodeFileTraceResult, NodeFileTraceReasons, Stats, NodeFileTraceReasonType } from './types';
-import { basename, dirname, extname, relative, resolve, sep } from 'path';
+import { basename, dirname, extname, relative, resolve, sep, join } from 'path';
+import * as url from 'url';
 import fs from 'graceful-fs';
 import analyze, { AnalyzeResult } from './analyze';
 import resolveDependency, { NotFoundError } from './resolve-dependency';
 import { isMatch } from 'micromatch';
 import { sharedLibEmit } from './utils/sharedlib-emit';
-import { join } from 'path';
 import { Sema } from 'async-sema';
 
 const fsReadFile = fs.promises.readFile;
@@ -24,12 +24,13 @@ export function parseSpecifier(specifier: string, cjsResolve: boolean = true): P
   let queryString = null;
 
   if (!cjsResolve) {
-    // Regex which splits a specifier into path and querystring, inspired by that in `enhanced-resolve`
-    // https://github.com/webpack/enhanced-resolve/blob/157ed9bcc381857d979e56d2f20a5a17c6362bff/lib/util/identifier.js#L8
-    const match = /^(#?(?:\0.|[^?#\0])*)(\?(?:\0.|[^\0])*)?$/.exec(specifier);
-    if (match) {
-      path = match[1]
-      queryString = match[2]
+    const specifierUrl = url.parse(specifier);
+    queryString = specifierUrl.search;
+
+    if (specifierUrl.search) {
+      path = specifier.replace(specifierUrl.search, '');
+    } else {
+      path = specifier;
     }
   }
 

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -239,6 +239,8 @@ export class Job {
   }
 
   private maybeEmitDep = async (dep: string, path: string, cjsResolve: boolean) => {
+    // Only affects ESM dependencies
+    const { path: strippedDep, queryString = '' } = parseSpecifier(dep, cjsResolve)
     let resolved: string | string[] = '';
     let error: Error | undefined;
     try {
@@ -447,8 +449,8 @@ export class Job {
         else
           await this.emitFile(asset, 'asset', path);
       }),
-      ...[...deps].map(async dep => this.maybeEmitDep(dep, path, !isESM)),
-      ...[...imports].map(async dep => this.maybeEmitDep(dep, path, false)),
+      ...[...deps].map(async dep => this.maybeEmitDep(dep, rawPath, !isESM)),
+      ...[...imports].map(async dep => this.maybeEmitDep(dep, rawPath, false)),
     ]);
   }
 }

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -268,9 +268,16 @@ export class Job {
 
     // For simplicity, force `resolved` to be an array
     resolved = Array.isArray(resolved) ? resolved : [resolved];
-    for (const item of resolved) {
-      // ignore builtins
+    for (let item of resolved) {
+      // ignore builtins for the purposes of both tracing and querystring handling (neither Node 
+      // nor Webpack can handle querystrings on `node:xxx` imports).
       if (item.startsWith('node:')) return;
+
+      // If querystring was stripped during resolution, restore it
+      if (queryString && !item.endsWith(queryString)) {
+        item += queryString;
+      }
+      
       await this.analyzeAndEmitDependency(item, path, cjsResolve);
     }
   }

--- a/src/resolve-dependency.ts
+++ b/src/resolve-dependency.ts
@@ -1,5 +1,5 @@
 import { isAbsolute, resolve, sep } from 'path';
-import { Job, parseSpecifier } from './node-file-trace';
+import { Job, splitQueryStringFromSpecifier } from './node-file-trace';
 
 // node resolver
 // custom implementation to emit only needed package.json files for resolver
@@ -9,7 +9,7 @@ export default async function resolveDependency (specifier: string, parent: stri
 
   // ESM imports are allowed to have querystrings, but the native Node behavior is to ignore them when doing
   // file resolution, so emulate that here by stripping any querystring off before continuing
-  specifier = parseSpecifier(specifier, cjsResolve).path
+  specifier = splitQueryStringFromSpecifier(specifier, cjsResolve).remainingSpecifier
 
   if (isAbsolute(specifier) || specifier === '.' || specifier === '..' || specifier.startsWith('./') || specifier.startsWith('../')) {
     const trailingSlash = specifier.endsWith('/');

--- a/test/unit/cjs-querystring/input.js
+++ b/test/unit/cjs-querystring/input.js
@@ -1,0 +1,7 @@
+// Test that CJS files treat question marks in filenames as any other character,
+// matching Node behavior
+
+// https://www.youtube.com/watch?v=2ve20PVNZ18
+
+const baseball = require('./who?what?idk!');
+console.log(baseball.players);

--- a/test/unit/cjs-querystring/noPunctuation/whowhatidk.js
+++ b/test/unit/cjs-querystring/noPunctuation/whowhatidk.js
@@ -1,0 +1,12 @@
+module.exports = {
+  players: {
+    first: 'Who',
+    second: 'What',
+    third: "I Don't Know",
+    left: 'Why',
+    center: 'Because',
+    pitcher: 'Tomorrow',
+    catcher: 'Today',
+    shortstop: "I Don't Give a Damn!",
+  },
+};

--- a/test/unit/cjs-querystring/output.js
+++ b/test/unit/cjs-querystring/output.js
@@ -1,0 +1,5 @@
+[
+  "package.json",
+  "test/unit/cjs-querystring/input.js",
+  "test/unit/cjs-querystring/who?what?idk!.js"
+]

--- a/test/unit/esm-querystring-mjs/animalFacts/aardvark.mjs
+++ b/test/unit/esm-querystring-mjs/animalFacts/aardvark.mjs
@@ -1,0 +1,4 @@
+import { numSpecies } from "./bear.mjs?beaver?bison";
+console.log(`There are ${numSpecies} species of bears.`);
+
+export const food = "termites";

--- a/test/unit/esm-querystring-mjs/animalFacts/bear.mjs
+++ b/test/unit/esm-querystring-mjs/animalFacts/bear.mjs
@@ -1,0 +1,4 @@
+import * as cheetah from "./cheetah.mjs?cow=chipmunk";
+console.log(`Cheetahs can run ${cheetah.topSpeed} mph.`);
+
+export const numSpecies = 8;

--- a/test/unit/esm-querystring-mjs/animalFacts/cheetah.mjs
+++ b/test/unit/esm-querystring-mjs/animalFacts/cheetah.mjs
@@ -1,0 +1,1 @@
+export const topSpeed = 65;

--- a/test/unit/esm-querystring-mjs/input.js
+++ b/test/unit/esm-querystring-mjs/input.js
@@ -1,0 +1,6 @@
+// Test that querystrings of various forms get stripped from esm imports when those
+// imports contain the `.mjs` file extension
+
+import * as aardvark from "./animalFacts/aardvark.mjs?anteater";
+
+console.log(`Aardvarks eat ${aardvark.food}.`);

--- a/test/unit/esm-querystring-mjs/output.js
+++ b/test/unit/esm-querystring-mjs/output.js
@@ -1,0 +1,7 @@
+[
+  "test/unit/esm-querystring-mjs/animalFacts/aardvark.mjs",
+  "test/unit/esm-querystring-mjs/animalFacts/bear.mjs",
+  "test/unit/esm-querystring-mjs/animalFacts/cheetah.mjs",
+  "test/unit/esm-querystring-mjs/input.js",
+  "test/unit/esm-querystring-mjs/package.json"
+]

--- a/test/unit/esm-querystring-mjs/package.json
+++ b/test/unit/esm-querystring-mjs/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/test/unit/esm-querystring/animalFacts/aardvark.js
+++ b/test/unit/esm-querystring/animalFacts/aardvark.js
@@ -1,0 +1,4 @@
+import { numSpecies } from './bear?beaver?bison';
+console.log(`There are ${numSpecies} species of bears.`);
+
+export const food = 'termites';

--- a/test/unit/esm-querystring/animalFacts/bear.js
+++ b/test/unit/esm-querystring/animalFacts/bear.js
@@ -1,0 +1,4 @@
+import * as cheetah from './cheetah?cow=chipmunk';
+console.log(`Cheetahs can run ${cheetah.topSpeed} mph.`);
+
+export const numSpecies = 8;

--- a/test/unit/esm-querystring/animalFacts/cheetah.js
+++ b/test/unit/esm-querystring/animalFacts/cheetah.js
@@ -1,0 +1,1 @@
+export const topSpeed = 65;

--- a/test/unit/esm-querystring/input.js
+++ b/test/unit/esm-querystring/input.js
@@ -1,0 +1,5 @@
+// Test that querystrings of various forms get stripped from esm imports
+
+import * as aardvark from './animalFacts/aardvark?anteater';
+
+console.log(`Aardvarks eat ${aardvark.food}.`);

--- a/test/unit/esm-querystring/output.js
+++ b/test/unit/esm-querystring/output.js
@@ -1,0 +1,7 @@
+[
+  "test/unit/esm-querystring/animalFacts/aardvark.js",
+  "test/unit/esm-querystring/animalFacts/bear.js",
+  "test/unit/esm-querystring/animalFacts/cheetah.js",
+  "test/unit/esm-querystring/input.js",
+  "test/unit/esm-querystring/package.json"
+]

--- a/test/unit/esm-querystring/package.json
+++ b/test/unit/esm-querystring/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/test/unit/querystring-self-import/base.js
+++ b/test/unit/querystring-self-import/base.js
@@ -1,0 +1,5 @@
+import * as dep from './dep';
+
+export const dogs = ['Charlie', 'Maisey'];
+export const cats = ['Piper'];
+export const rats = dep.rats;

--- a/test/unit/querystring-self-import/dep.js
+++ b/test/unit/querystring-self-import/dep.js
@@ -1,0 +1,1 @@
+export const rats = ['Debra'];

--- a/test/unit/querystring-self-import/input.js
+++ b/test/unit/querystring-self-import/input.js
@@ -1,0 +1,10 @@
+// Test that if a file and the same file with a querystring correspond to different
+// modules in memory, one can successfully import the other. The import chain
+// goes `input` (this file) -> `base?__withQuery` -> `base` -> `dep`, which means
+// that if `dep` shows up in `output`, we know that both `base?__withQuery` and
+// `base` have been loaded successfully.
+
+import * as baseWithQuery from './base?__withQuery';
+console.log('Dogs:', baseWithQuery.dogs);
+console.log('Cats:', baseWithQuery.cats);
+console.log('Rats:', baseWithQuery.rats);

--- a/test/unit/querystring-self-import/output.js
+++ b/test/unit/querystring-self-import/output.js
@@ -1,0 +1,6 @@
+[
+  "package.json",
+  "test/unit/querystring-self-import/base.js",
+  "test/unit/querystring-self-import/dep.js",
+  "test/unit/querystring-self-import/input.js"
+]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,10 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
-    "lib": ["esnext"],
+    "lib": [
+      "esnext",
+      "DOM" // needed for "new URL()"
+    ],
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmitOnError": true,


### PR DESCRIPTION
Note: This PR is built on top of https://github.com/vercel/nft/pull/322 which I took over because @lobsterkatie is currently out. 

---

Currently, there are two problems with the way `@vercel/nft` handles ESM imports with querystrings (`import * as something from './someFile?someQuerystring';`):

* It treats the `?` as it would any other character. As a result, it fails to resolve such imports to the non-querystringed files to which they correspond. (In the above example, it looks for a file named `someFile?someQuerystring.js` and, as one would expect, doesn't find it.) While this is the correct behavior for `require` calls in CJS files, it doesn't match the way that Node handles ESM imports (which is to strip the querystring off before attempting to resolve the file).
* In cases where a custom `resolve` method is provided, and that custom method _does_ strip querystrings from ESM imports, the querystrings are then not put back on before the imported module is processed. This matters, for example, in cases where `readFile` is also overridden, with a method whose output is affected by the querystring's value. (Webpack is such a system, so one place this shows up is in [Next.js's `NextTraceEntryPointsPlugin`](https://github.com/vercel/next.js/blob/3d4c038fa5c314f5800b8caeee7ada8c385cb3ce/packages/next/build/webpack/plugins/next-trace-entrypoints-plugin.ts).)

This fixes both of those problems by selectively stripping and re-adding the querystring in ESM imports at various points in the `nodeFileTrace` lifecycle. More specifically, in `resolveDependecy` and in `emitDependency` and its helpers, we strip the querystring (and/or don't add it back), with the exception of:

* When we're marking a path  as seen, we keep the querystring so that having a different querystring makes the process run again.
* When we're calling `readFile`, we keep the querystring, since some implementations of `readFile`, including the one in the nft webpack plugin, read different modules out of memory with different querystrings).
* When we're calling `resolve`, we add the querystring back in, since this is also something which can be supplied by the user, and and the user-supplied version might care about query strings.
* When we're caching analysis results, we keep the querystring, since again here, we may have different code to analyze if we have a different querystring.
* When we're making the recursive call to `emitDependency`, we add the querystring back in, since we need it there to be able to start the whole cycle over.

Notes:

* Because the behavior here depends on whether or not a module is ESM, I needed to pass `cjsResolve` to the recursive call of `emitDependency`. Rather than change `emitDependency`'s signature, I opted to make `emitDependency` a wrapper for an inner function (`analyzeAndEmitDependency`) with the updated signature. Recursive calls now go to the inner function.
* For context, we on the `@sentry/nextjs` team are interested in this because we use a [webpack loader](https://github.com/getsentry/sentry-javascript/blob/c9a01ff98cdde31de217f0d47ad2626f867d6eaa/packages/nextjs/src/config/loaders/proxyLoader.ts) to insert in the dependency tree a [proxy module](https://github.com/getsentry/sentry-javascript/blob/c9a01ff98cdde31de217f0d47ad2626f867d6eaa/packages/nextjs/src/config/templates/pageProxyLoaderTemplate.ts) for each page, which allows us to automatically wrap users' exported functions (`getServerSideProps` and friends, API route handlers, etc). To do this, we replace the code from `/path/to/pages/somePage.js` with our proxy code, which includes an import from `'./somePage?__sentry_wrapped__'`. When webpack then crawls our proxy module looking for dependencies, the querystring tricks it into thinking it hasn't yet dealt with that page, so it forwards it to our loader a second time rather than skipping it. When our loader sees the querystring, it knows the code replacement has already been done, and returns the original page code untouched, thereby preserving the continuity of the dependency tree. This fix ensures that `@vercel/nft` successfully traces the modified tree.
* The unit test testing that this doesn't break the (already correct) behavior in CJS when dealing with files with question marks in their names (`cjs-querystring`) required a little gymnastics in order to not break CI on Windows. It turns out that skipping the test on Windows wasn't enough - the mere fact that a file exists with a `?` in its name is enough to cause Windows not to even be able to check out the commit. Therefore, the file is stored without any punctuation in its name, and before the tests run on non-Windows platforms, it is copied to a version which does have the punctuation, and which is git-ignored to enforce it not ending up in the repo in the future by accident. The dummy, no-punctuation version is stored in a folder in order to differentiate its path from that of the punctuated version by more than just the punctuation. That way, if the punctuated version is found, it's clear it's not just because the punctuation is somehow being ignored.

Fixes [getsentry/sentry-javascript#5998](https://github.com/getsentry/sentry-javascript/issues/5998).
Fixes #319.