### PR TITLE
chore: update ecmascript tests

### DIFF
--- a/test/ecmascript/data-common.json
+++ b/test/ecmascript/data-common.json
@@ -137,20 +137,50 @@
     }
   },
   "graalvm": {
+    "es6flag": {
+      "val": "flagged",
+      "note_id": "graalvm-js-ecmascript-version-6",
+      "note_html": "Requires the <code>--js.ecmascript-version=6</code> flag."
+    },
     "es2020flag": {
       "val": "flagged",
-      "note_id": "graalvm-es2020",
-      "note_html": "The feature can be enabled via <code>--js.ecmascript-version=2020</code> flag"
+      "note_id": "graalvm-js-ecmascript-version-2020",
+      "note_html": "Requires the <code>--js.ecmascript-version=2020</code> flag."
     },
     "es2021flag": {
       "val": "flagged",
-      "note_id": "graalvm-es2021",
-      "note_html": "The feature can be enabled via <code>--js.ecmascript-version=2021</code> flag"
+      "note_id": "graalvm-js-ecmascript-version-2021",
+      "note_html": "Requires the <code>--js.ecmascript-version=2021</code> flag."
     },
     "es2022flag": {
       "val": "flagged",
-      "note_id": "graalvm-es2022",
-      "note_html": "The feature can be enabled via <code>--js.ecmascript-version=2022</code> flag"
+      "note_id": "graalvm-js-ecmascript-version-2022",
+      "note_html": "Requires the <code>--js.ecmascript-version=2022</code> flag."
+    },
+    "esStagingFlag": {
+      "val": "flagged",
+      "note_id": "graalvm-js-ecmascript-version-staging",
+      "note_html": "Requires the <code>--js.ecmascript-version=staging</code> flag."
+    },
+    "newSetMethodsFlag": {
+      "val": "flagged",
+      "note_id": "graalvm-experimental-options-js-new-set-methods",
+      "note_html": "Requires the <code>--experimental-options --js.new-set-methods</code> flags."
+    },
+    "v8CompatFlag": {
+      "val": "flagged",
+      "note_id": "graalvm-experimental-options-js-v8-compat",
+      "note_html": "Requires the <code>--experimental-options --js.v8-compat</code> flags."
+    },
+    "nashornCompatFlag": {
+      "val": "flagged",
+      "note_id": "graalvm-experimental-options-js-nashorn-compat",
+      "note_html": "Requires the <code>--experimental-options --js.nashorn-compat</code> flags."
+    },
+    "globalPropertyFlag": {
+      "val": "flagged",
+      "note_id": "graalvm-experimental-options-js-global-property",
+      "note_html": "Requires the <code>--experimental-options --js.global-property</code> flags."
     }
   },
   "hermes": {

--- a/test/ecmascript/data-es2016plus.js
+++ b/test/ecmascript/data-es2016plus.js
@@ -42,10 +42,10 @@ exports.tests = [
           duktape2_0: true,
           jerryscript2_3_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7_13: false
+          reactnative0_70_3: true,
+          rhino1_7_13: false,
+          rhino1_7_14: true,
         }
       },
       {
@@ -71,10 +71,10 @@ exports.tests = [
           duktape2_0: true,
           jerryscript2_3_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7_13: false
+          reactnative0_70_3: true,
+          rhino1_7_13: false,
+          rhino1_7_14: true,
         }
       },
       {
@@ -101,10 +101,10 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7_13: false
+          reactnative0_70_3: true,
+          rhino1_7_13: false,
+          rhino1_7_14: true,
         }
       }
     ]
@@ -145,10 +145,10 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7_13: false
+          reactnative0_70_3: true,
+          rhino1_7_13: false,
+          rhino1_7_14: true,
         }
       },
       {
@@ -183,10 +183,10 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7_13: false
+          reactnative0_70_3: true,
+          rhino1_7_13: false,
+          rhino1_7_14: true,
         }
       },
       {
@@ -221,9 +221,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -249,9 +248,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -271,8 +269,7 @@ exports.tests = [
          return [1, 2, 3].includes(1)
          && ![1, 2, 3].includes(4)
          && ![1, 2, 3].includes(1, 1)
-         && [NaN].includes(NaN)
-         && Array(1).includes();
+         && [NaN].includes(NaN);
          */},
         res: {
           babel6corejs2: babel.corejs,
@@ -290,9 +287,38 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
+          rhino1_7_13: true
+        }
+      },
+      {
+        name: 'Array.prototype.includes handles sparse arrays',
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes',
+        exec: function(){/*
+         return [,].includes()
+          && Array(1).includes();
+         */},
+        res: {
+          babel6corejs2: babel.corejs,
+          closure: true,
+          es7shim: true,
+          typescript1corejs2: typescript.corejs,
+          safari9: true,
+          chrome47: true,
+          ie11: false,
+          edge14: true,
+          firefox2: false,
+          firefox43: true,
+          firefox99: false,
+          firefox102: true,
+          opera10_50: false,
+          duktape2_0: false,
+          jerryscript2_3_0: false,
+          jerryscript2_4_0: true,
+          graalvm19: true,
+          hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -325,6 +351,7 @@ exports.tests = [
          */},
         res: {
           babel6corejs2: babel.corejs,
+          closure: false,
           closure20180402: true,
           es7shim: true,
           typescript1corejs2: typescript.corejs,
@@ -339,10 +366,10 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7_13: false
+          reactnative0_70_3: true,
+          rhino1_7_13: false,
+          rhino1_7_14: true,
         }
       },
       {
@@ -370,9 +397,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -415,9 +441,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -452,9 +477,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       }
@@ -490,9 +514,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -518,9 +541,8 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       }
@@ -568,9 +590,9 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -609,9 +631,9 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -619,12 +641,13 @@ exports.tests = [
         name: 'no line break between async and function',
         exec: function () {/*
           async function a(){}
-          try { Function("async\n function a(){}")(); } catch(e) { return true; }
+          try { Function("async\n function a(){await 0}")(); } catch(e) { return true; }
         */},
         res: {
           tr: null,
           babel6corejs2: null,
-          closure: false,
+          babel7corejs3: true,
+          closure: true,
           typescript1corejs2: null,
           chrome52: null,
           chrome55: true,
@@ -639,9 +662,9 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -668,9 +691,9 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -704,9 +727,9 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -742,9 +765,9 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -757,6 +780,7 @@ exports.tests = [
         res: {
           tr: null,
           babel6corejs2: null,
+          babel7corejs3: true,
           closure: true,
           typescript1corejs2: null,
           chrome52: null,
@@ -771,9 +795,9 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -806,9 +830,9 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -821,6 +845,7 @@ exports.tests = [
         res: {
           tr: null,
           babel6corejs2: null,
+          babel7corejs3: true,
           closure: false,
           closure20200614: true,
           typescript1corejs2: null,
@@ -836,9 +861,8 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -876,9 +900,9 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -916,9 +940,8 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -957,9 +980,8 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -994,9 +1016,8 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -1026,9 +1047,9 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1055,9 +1076,9 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1094,9 +1115,9 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       }
@@ -1165,9 +1186,8 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1201,9 +1221,8 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1240,9 +1259,8 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1278,9 +1296,8 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1316,9 +1333,8 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1355,9 +1371,8 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1394,9 +1409,8 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1433,9 +1447,8 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1472,9 +1485,8 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1511,18 +1523,17 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
       {
-        name: 'Atomics.wake',
-        spec: 'https://tc39.github.io/ecma262/#sec-atomics.wake',
-        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wake',
+        name: 'Atomics.notify',
+        spec: 'https://tc39.github.io/ecma262/#sec-atomics.notify',
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/notify',
         exec: function () {/*
-         return typeof Atomics.wake === 'function';
+         return typeof Atomics.notify === 'function';
          */},
         res: {
           ie11: false,
@@ -1550,9 +1561,9 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: false,
-          graalvm20: false,
-          graalvm20_1: false,
+          graalvm20: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1589,9 +1600,8 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1628,9 +1638,8 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1667,9 +1676,8 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1706,9 +1714,8 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1745,9 +1752,8 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -1784,9 +1790,8 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       }
@@ -1825,9 +1830,8 @@ exports.tests = [
       duktape2_0: false,
       jerryscript2_3_0: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -1861,6 +1865,7 @@ exports.tests = [
      */},
     res: {
       babel7corejs3: true,
+      closure: false,
       closure20180319: true,
       typescript1corejs2: typescript.downlevelIteration,
       ie11: false,
@@ -1875,9 +1880,8 @@ exports.tests = [
       duktape2_0: false,
       jerryscript2_3_0: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: true
     }
   },
@@ -1901,6 +1905,7 @@ exports.tests = [
      }
      */},
     res: {
+      babel7corejs3: true,
       ie11: false,
       edge12: true,
       firefox2: false,
@@ -1911,9 +1916,8 @@ exports.tests = [
       duktape2_0: false,
       jerryscript2_3_0: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -1948,9 +1952,8 @@ exports.tests = [
       duktape2_0: false,
       jerryscript2_3_0: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -1985,9 +1988,8 @@ exports.tests = [
       duktape2_0: false,
       jerryscript2_3_0: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -2027,9 +2029,8 @@ exports.tests = [
       jerryscript2_3_0: false,
       jerryscript2_4_0: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -2062,9 +2063,8 @@ exports.tests = [
       jerryscript2_3_0: false,
       jerryscript2_4_0: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -2103,9 +2103,8 @@ exports.tests = [
         jerryscript2_3_0: false,
         jerryscript2_4_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -2138,9 +2137,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -2173,9 +2171,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -2209,9 +2206,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -2244,9 +2240,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -2279,9 +2274,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -2316,9 +2310,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -2353,9 +2346,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -2390,9 +2382,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -2423,9 +2414,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -2456,9 +2446,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -2493,9 +2482,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -2530,9 +2518,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -2567,9 +2554,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -2600,9 +2586,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -2633,9 +2618,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       }
@@ -2667,9 +2651,8 @@ exports.tests = [
         jerryscript2_3_0: false,
         jerryscript2_4_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2694,9 +2677,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -2727,9 +2709,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -2760,9 +2741,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -2798,8 +2778,8 @@ exports.tests = [
       jerryscript2_4_0: true,
       graalvm19: false,
       graalvm20: true,
-      graalvm20_1: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -2826,9 +2806,8 @@ exports.tests = [
       jerryscript2_3_0: false,
       jerryscript2_4_0: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       hermes0_7_0: false,
+      reactnative0_70_3: false,
       rhino1_7_13: false
     }
   },
@@ -2844,6 +2823,7 @@ exports.tests = [
      */},
     res: {
       tr: true,
+      babel7corejs3: true,
       ie10: true,
       edge12: true,
       firefox2: true,
@@ -2864,9 +2844,8 @@ exports.tests = [
       nashorn10: true,
       jerryscript2_3_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       hermes0_7_0: true,
+      reactnative0_70_3: false,
       rhino1_7_13: true
     }
   },
@@ -2896,9 +2875,8 @@ exports.tests = [
       jerryscript2_3_0: false,
       jerryscript2_4_0: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       hermes0_7_0: false,
+      reactnative0_70_3: false,
       rhino1_7_13: false
     }
   },
@@ -2939,9 +2917,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -2976,9 +2953,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -3024,6 +3000,7 @@ exports.tests = [
       */},
         res: {
           babel6corejs2: babel.corejs,
+          closure: false,
           closure20180402: true,
           typescript1corejs2: typescript.corejs,
           ie11: false,
@@ -3041,9 +3018,9 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -3072,6 +3049,7 @@ exports.tests = [
       */},
         res: {
           babel6corejs2: babel.corejs,
+          closure: false,
           closure20180402: true,
           typescript1corejs2: typescript.corejs,
           ie11: false,
@@ -3089,9 +3067,9 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -3122,6 +3100,7 @@ exports.tests = [
       */},
         res: {
           babel6corejs2: babel.corejs,
+          closure: false,
           closure20180402: true,
           typescript1corejs2: typescript.corejs,
           ie11: false,
@@ -3139,9 +3118,9 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -3163,6 +3142,8 @@ exports.tests = [
      return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
      */},
     res: {
+      babel7corejs3: true,
+      closure: false,
       closure20181008: true,
       closure20200315: false,
       closure20200517: true,
@@ -3176,10 +3157,10 @@ exports.tests = [
       duktape2_0: false,
       jerryscript2_3_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       hermes0_7_0: true,
-      rhino1_7_13: false
+      reactnative0_70_3: true,
+      rhino1_7_13: false,
+      rhino1_7_14: true,
     }
   },
   {
@@ -3200,7 +3181,7 @@ exports.tests = [
       jsx: null,
       typescript1corejs2: null,
       es6shim: null,
-      konq414: null,
+      konq4_14: null,
       ie7: null,
       ie10: false,
       firefox1: null,
@@ -3224,9 +3205,8 @@ exports.tests = [
       android1_5: null,
       ios4: null,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -3260,9 +3240,8 @@ exports.tests = [
       duktape2_0: false,
       jerryscript2_3_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       hermes0_7_0: false,
+      reactnative0_70_3: false,
       rhino1_7_13: false
     }
   },
@@ -3277,6 +3256,7 @@ exports.tests = [
            !/(?<=a)b/.test('b');
   */},
     res : {
+      babel7corejs3: false,
       ie11: false,
       firefox2: false,
       firefox77: false,
@@ -3288,10 +3268,10 @@ exports.tests = [
       duktape2_0: false,
       jerryscript2_3_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       hermes0_7_0: true,
-      rhino1_7_13: false
+      reactnative0_70_3: true,
+      rhino1_7_13: false,
+      safaritp: true
     }
   },
   {
@@ -3318,9 +3298,8 @@ exports.tests = [
       duktape2_0: false,
       jerryscript2_3_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       hermes0_7_0: false,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -3344,6 +3323,7 @@ exports.tests = [
         */},
         res: {
           babel6corejs2: true,
+          closure: false,
           closure20180805: true,
           chrome62: chrome.harmony,
           chrome63: true,
@@ -3359,9 +3339,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -3390,6 +3369,7 @@ exports.tests = [
         */},
         res: {
           babel6corejs2: true,
+          closure: false,
           closure20180910: true,
           chrome62: chrome.harmony,
           chrome63: true,
@@ -3405,9 +3385,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       }
@@ -3432,6 +3411,7 @@ exports.tests = [
         */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20190215: true,
           typescript2_5corejs2: true,
           ie11: false,
@@ -3448,9 +3428,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -3468,6 +3447,7 @@ exports.tests = [
         */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20190215: true,
           typescript2_5corejs2: true,
           ie11: false,
@@ -3484,9 +3464,9 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -3508,6 +3488,7 @@ exports.tests = [
         */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20190215: true,
           typescript2_5corejs2: true,
           ie11: false,
@@ -3523,8 +3504,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -3545,6 +3526,7 @@ exports.tests = [
         res : {
           babel6corejs2: false,
           babel7corejs3: babel.corejs,
+          closure: false,
           closure20190301: true,
           typescript1corejs2: typescript.fallthrough,
           typescript3_2corejs3: typescript.corejs,
@@ -3562,9 +3544,9 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -3576,6 +3558,7 @@ exports.tests = [
         res : {
           babel6corejs2: false,
           babel7corejs3: babel.corejs,
+          closure: false,
           closure20190301: true,
           typescript1corejs2: typescript.fallthrough,
           typescript3_2corejs3: typescript.corejs,
@@ -3593,9 +3576,9 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -3625,9 +3608,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       }
@@ -3656,9 +3638,8 @@ exports.tests = [
         duktape2_0: false,
         jerryscript2_3_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }, {
@@ -3682,9 +3663,8 @@ exports.tests = [
         nashorn10: true,
         jerryscript2_3_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }, {
@@ -3708,9 +3688,8 @@ exports.tests = [
         nashorn10: true,
         jerryscript2_3_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }, {
@@ -3731,9 +3710,8 @@ exports.tests = [
         duktape2_0: false,
         jerryscript2_3_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }, {
@@ -3754,9 +3732,8 @@ exports.tests = [
         duktape2_0: false,
         jerryscript2_3_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }, {
@@ -3775,9 +3752,8 @@ exports.tests = [
         duktape2_0: false,
         jerryscript2_3_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }, {
@@ -3798,9 +3774,8 @@ exports.tests = [
         nashorn10: true,
         jerryscript2_3_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }]
@@ -3817,6 +3792,7 @@ exports.tests = [
           return eval("'\u2028'") === "\u2028";
         */},
         res : {
+          closure: false,
           closure20190215: true,
           babel7corejs2: true,
           ie11: false,
@@ -3831,10 +3807,10 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7_13: false
+          reactnative0_70_3: true,
+          rhino1_7_13: false,
+          rhino1_7_14: true,
         }
       },
       {
@@ -3843,6 +3819,7 @@ exports.tests = [
           return eval("'\u2029'") === "\u2029";
         */},
         res : {
+          closure: false,
           closure20190215: true,
           babel7corejs2: true,
           ie11: false,
@@ -3857,10 +3834,10 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7_13: false
+          reactnative0_70_3: true,
+          rhino1_7_13: false,
+          rhino1_7_14: true,
         }
       }
     ]
@@ -3878,6 +3855,7 @@ exports.tests = [
     res: {
       babel6corejs2: false,
       babel7corejs3: babel.corejs,
+      closure: false,
       closure20190325: true,
       typescript1corejs2: typescript.fallthrough,
       typescript3_2corejs3: typescript.corejs,
@@ -3892,12 +3870,12 @@ exports.tests = [
       jerryscript2_3_0: false,
       jerryscript2_4_0: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       chrome73: true,
       chrome74: true,
       hermes0_7_0: true,
-      rhino1_7_13: false
+      reactnative0_70_3: true,
+      rhino1_7_13: false,
+      rhino1_7_14: true,
     }
   },
   {
@@ -3931,9 +3909,8 @@ exports.tests = [
       jerryscript2_3_0: false,
       jerryscript2_4_0: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       hermes0_7_0: false,
+      reactnative0_70_3: false,
       rhino1_7_13: false
     }
   },
@@ -3951,6 +3928,7 @@ exports.tests = [
       */},
         res: {
           babel6corejs2: babel.corejs,
+          closure: false,
           closure20190709: true,
           typescript1corejs2: typescript.corejs,
           ie11: false,
@@ -3964,7 +3942,7 @@ exports.tests = [
           konq4_4: false,
           konq4_9: true,
           besen: false,
-          phantom: true,
+          phantom1_9: true,
           node0_12: true,
           safari3: false,
           safari4: true,
@@ -3980,9 +3958,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -3994,6 +3971,7 @@ exports.tests = [
       */},
         res: {
           babel6corejs2: babel.corejs,
+          closure: false,
           closure20190709: true,
           typescript1corejs2: typescript.corejs,
           ie11: false,
@@ -4007,7 +3985,7 @@ exports.tests = [
           konq4_4: false,
           konq4_9: true,
           besen: false,
-          phantom: true,
+          phantom1_9: true,
           node0_12: true,
           safari3: false,
           safari4: true,
@@ -4023,9 +4001,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -4037,6 +4014,7 @@ exports.tests = [
       */},
         res: {
           babel6corejs2: babel.corejs,
+          closure: false,
           closure20190325: {
             val: false,
             note_id: 'closure-string-trimstart',
@@ -4056,9 +4034,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       },
@@ -4070,6 +4047,7 @@ exports.tests = [
       */},
         res: {
           babel6corejs2: babel.corejs,
+          closure: false,
           closure20190325: {
             val: false,
             note_id: 'closure-string-trimend',
@@ -4089,9 +4067,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: true
         }
       }
@@ -4118,6 +4095,7 @@ exports.tests = [
         res: {
           babel6corejs2: false,
           babel7corejs3: babel.corejs,
+          closure: false,
           closure20190301: true,
           typescript1corejs2: typescript.fallthrough,
           typescript3_2corejs3: typescript.corejs,
@@ -4138,9 +4116,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -4154,6 +4131,7 @@ exports.tests = [
       */},
         res: {
           babel6corejs2: babel.corejs,
+          closure: false,
           closure20190301: true,
           typescript1corejs2: typescript.corejs,
           ie11: false,
@@ -4168,9 +4146,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -4201,9 +4178,8 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       }
@@ -4233,6 +4209,7 @@ exports.tests = [
         */},
         res: {
           babel6corejs2: babel.corejs,
+          closure: false,
           closure20200101: true,
           typescript1corejs2: typescript.corejs,
           ie11: false,
@@ -4254,6 +4231,7 @@ exports.tests = [
           graalvm20: graalvm.es2020flag,
           graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -4270,6 +4248,7 @@ exports.tests = [
         res: {
           babel6corejs2: false,
           babel7corejs3: babel.corejs,
+          closure: false,
           closure20200101: true,
           typescript1corejs2: typescript.fallthrough,
           typescript3_2corejs3: typescript.corejs,
@@ -4294,6 +4273,7 @@ exports.tests = [
           graalvm20: graalvm.es2020flag,
           graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -4325,10 +4305,11 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7_13: false
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
+          rhino1_7_13: false,
+          rhino1_7_14: true,
         }
       },
       {
@@ -4350,10 +4331,11 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7_13: false
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
+          rhino1_7_13: false,
+          rhino1_7_14: true,
         }
       },
       {
@@ -4374,10 +4356,11 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7_13: false
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
+          rhino1_7_13: false,
+          rhino1_7_14: true,
         }
       },
       {
@@ -4398,10 +4381,11 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7_13: false
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
+          rhino1_7_13: false,
+          rhino1_7_14: true,
         }
       },
       {
@@ -4425,9 +4409,9 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -4452,9 +4436,9 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -4480,9 +4464,9 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -4508,9 +4492,9 @@ exports.tests = [
           jerryscript2_3_0: false,
           jerryscript2_4_0: true,
           graalvm19: true,
-          graalvm20: true,
-          graalvm20_1: true,
           hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -4539,6 +4523,7 @@ exports.tests = [
     res: {
       babel6corejs2: false,
       babel7corejs3: babel.corejs,
+      closure: false,
       closure20191027: true,
       typescript1corejs2: typescript.fallthrough,
       typescript3_2corejs3: typescript.corejs,
@@ -4554,6 +4539,7 @@ exports.tests = [
       graalvm20: graalvm.es2020flag,
       graalvm20_1: true,
       hermes0_7_0: false,
+      reactnative0_70_3: false,
       rhino1_7_13: false
     }
   },
@@ -4573,6 +4559,7 @@ exports.tests = [
       res: {
         babel6corejs2: false,
         babel7corejs3: babel.corejs,
+        closure: false,
         closure20200101: true,
         typescript1corejs2: typescript.fallthrough,
         typescript3_2corejs3: typescript.corejs,
@@ -4601,10 +4588,10 @@ exports.tests = [
         jerryscript2_3_0: false,
         jerryscript2_4_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        reactnative0_70_3: true,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     }, {
       name: '"globalThis" global property has correct property descriptor',
@@ -4620,6 +4607,7 @@ exports.tests = [
       res: {
         babel6corejs2: false,
         babel7corejs3: babel.corejs,
+        closure: false,
         closure20200101: true,
         typescript1corejs2: typescript.fallthrough,
         typescript3_2corejs3: typescript.corejs,
@@ -4648,10 +4636,10 @@ exports.tests = [
         jerryscript2_3_0: false,
         jerryscript2_4_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        reactnative0_70_3: true,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     }]
   },
@@ -4671,6 +4659,7 @@ exports.tests = [
         */},
         res : {
           babel7corejs2: true,
+          closure: false,
           closure20200927: true,
           typescript3_7corejs3: true,
           ie11: false,
@@ -4689,6 +4678,7 @@ exports.tests = [
           graalvm20: graalvm.es2020flag,
           graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -4701,6 +4691,7 @@ exports.tests = [
         */},
         res : {
           babel7corejs2: true,
+          closure: false,
           closure20200927: true,
           typescript3_7corejs3: true,
           ie11: false,
@@ -4719,6 +4710,7 @@ exports.tests = [
           graalvm20: graalvm.es2020flag,
           graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -4731,6 +4723,7 @@ exports.tests = [
         */},
         res : {
           babel7corejs2: true,
+          closure: false,
           closure20200927: true,
           typescript3_7corejs3: true,
           ie11: false,
@@ -4749,6 +4742,7 @@ exports.tests = [
           graalvm20: graalvm.es2020flag,
           graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -4763,6 +4757,7 @@ exports.tests = [
         */},
         res : {
           babel7corejs2: true,
+          closure: false,
           closure20200927: true,
           typescript3_7corejs3: true,
           ie11: false,
@@ -4781,6 +4776,7 @@ exports.tests = [
           graalvm20: graalvm.es2020flag,
           graalvm20_1: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -4794,6 +4790,8 @@ exports.tests = [
           return fn?.(...[], 1) === void undefined && fn?.(...[], ...[]) === void undefined && o.method?.(...[], 1) === void undefined && n?.method(...[], 1) === void undefined;
         */},
         res : {
+          babel7corejs3: true,
+          closure: false,
           closure20200927: true,
           ie11: false,
           firefox10: false,
@@ -4808,6 +4806,10 @@ exports.tests = [
           safari13_1: true,
           safaritp: true,
           duktape2_0: false,
+          graalvm21_3_3: true,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -4848,6 +4850,7 @@ exports.tests = [
       graalvm20: graalvm.es2020flag,
       graalvm20_1: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -4863,6 +4866,7 @@ exports.tests = [
     res: {
       babel6corejs2: false,
       babel7corejs3: babel.corejs,
+      closure: false,
       closure20210808: true,
       typescript1corejs2: typescript.fallthrough,
       typescript3_2corejs3: typescript.corejs,
@@ -4886,6 +4890,7 @@ exports.tests = [
       graalvm21: true,
       ios13_4: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -4910,6 +4915,7 @@ exports.tests = [
         res: {
           babel6corejs2: false,
           babel7corejs3: babel.corejs,
+          closure: false,
           closure20210808: true,
           typescript1corejs2: typescript.fallthrough,
           typescript3_2corejs3: typescript.corejs,
@@ -4928,6 +4934,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -4945,6 +4952,7 @@ exports.tests = [
         res: {
           babel6corejs2: false,
           babel7corejs3: babel.corejs,
+          closure: false,
           closure20210808: true,
           typescript1corejs2: typescript.fallthrough,
           typescript3_2corejs3: typescript.corejs,
@@ -4960,6 +4968,7 @@ exports.tests = [
           safaritp: true,
           duktape2_0: false,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false,
           jerryscript2_3_0: false,
           graalvm20_3: graalvm.es2021flag,
@@ -5005,6 +5014,7 @@ exports.tests = [
           graalvm20: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -5030,11 +5040,10 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: false,
-          graalvm20: false,
-          graalvm20_1: false,
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       }
@@ -5060,6 +5069,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20210808: true,
           ie11: false,
           firefox60: false,
@@ -5077,6 +5087,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5090,6 +5101,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20210808: true,
           ie11: false,
           firefox60: false,
@@ -5107,6 +5119,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5120,6 +5133,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20210808: true,
           ie11: false,
           firefox60: false,
@@ -5137,6 +5151,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5154,6 +5169,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20210808: true,
           ie11: false,
           firefox60: false,
@@ -5171,6 +5187,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5184,6 +5201,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20210808: true,
           ie11: false,
           firefox60: false,
@@ -5201,6 +5219,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5214,6 +5233,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20210808: true,
           ie11: false,
           firefox60: false,
@@ -5231,6 +5251,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5248,6 +5269,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20210808: true,
           ie11: false,
           firefox60: false,
@@ -5265,6 +5287,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5278,6 +5301,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20210808: true,
           ie11: false,
           firefox60: false,
@@ -5295,6 +5319,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5308,6 +5333,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20210808: true,
           ie11: false,
           firefox60: false,
@@ -5325,6 +5351,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -5341,6 +5368,7 @@ exports.tests = [
     */},
     res : {
       babel7corejs2: true,
+      closure: false,
       closure20210808: true,
       typescript1corejs2: false,
       typescript2_7corejs2: true,
@@ -5362,7 +5390,9 @@ exports.tests = [
       graalvm20: graalvm.es2020flag,
       graalvm20_1: true,
       hermes0_7_0: true,
-      rhino1_7_13: false
+      reactnative0_70_3: true,
+      rhino1_7_13: false,
+      rhino1_7_14: true,
     }
   },
   {
@@ -5396,7 +5426,8 @@ exports.tests = [
           duktape2_0: false,
           graalvm19: false,
           graalvm20: true,
-          graalvm20_1: true,
+          hermes0_7_0: false,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5430,7 +5461,8 @@ exports.tests = [
           duktape2_0: false,
           graalvm19: false,
           graalvm20: true,
-          graalvm20_1: true,
+          hermes0_7_0: false,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5460,7 +5492,8 @@ exports.tests = [
           duktape2_0: false,
           graalvm19: false,
           graalvm20: true,
-          graalvm20_1: true,
+          hermes0_7_0: false,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5477,6 +5510,7 @@ exports.tests = [
         */},
         res: {
           babel7corejs2: true,
+          babel7corejs3: true,
           ie11: false,
           firefox2: false,
           firefox80: firefox.privateFields,
@@ -5491,10 +5525,10 @@ exports.tests = [
           duktape2_0: false,
           opera10_50: false,
           graalvm20: false,
-          graalvm20_1: false,
           graalvm20_3: true,
-          babel7corejs3: false,
           typescript3_8corejs3: false,
+          hermes0_7_0: false,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5511,6 +5545,7 @@ exports.tests = [
         */},
         res: {
           babel7corejs2: true,
+          babel7corejs3: true,
           ie11: false,
           firefox2: false,
           firefox74: firefox.privateClassFields,
@@ -5526,10 +5561,10 @@ exports.tests = [
           opera10_50: false,
           duktape2_0: false,
           graalvm20: false,
-          graalvm20_1: false,
           graalvm20_3: true,
-          babel7corejs3: false,
           typescript3_8corejs3: false,
+          hermes0_7_0: false,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5555,7 +5590,8 @@ exports.tests = [
           duktape2_0: false,
           graalvm19: false,
           graalvm20: true,
-          graalvm20_1: true,
+          hermes0_7_0: false,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -5592,8 +5628,45 @@ exports.tests = [
           duktape2_0: false,
           graalvm19: false,
           graalvm20: true,
-          graalvm20_1: true,
+          hermes0_7_0: false,
+          reactnative0_70_3: true,
           rhino1_7_13: false
+        }
+      },
+      {
+        name: 'static class fields use [[Define]]',
+        exec: function () { /*
+          return (class X { static name = "name"; }).name === 'name';
+        */},
+        res: {
+          chrome73: true,
+          chrome90: true,
+          chrome94: true,
+          chrome96: true,
+          chrome97: false,
+          chrome98: true,
+          firefox95: true,
+          firefox96: true,
+          node11_0: false,
+          node12_0: true,
+          node12_5: true,
+          node12_9: true,
+          node12_11: true,
+          node13_0: true,
+          node13_2: true,
+          node14_0: true,
+          node14_5: true,
+          node14_6: true,
+          node15_0: true,
+          node16_0: true,
+          node16_9: true,
+          node16_11: true,
+          safari15: true,
+          duktape2_0: false,
+          graalvm21_3_3: false,
+          graalvm22_2: true,
+          hermes0_7_0: false,
+          reactnative0_70_3: true
         }
       },
       {
@@ -5621,7 +5694,8 @@ exports.tests = [
           duktape2_0: false,
           graalvm19: false,
           graalvm20: true,
-          graalvm20_1: true,
+          hermes0_7_0: false,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5646,7 +5720,8 @@ exports.tests = [
           duktape2_0: false,
           graalvm19: false,
           graalvm20: true,
-          graalvm20_1: true,
+          hermes0_7_0: false,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -5690,6 +5765,8 @@ exports.tests = [
           safaritp: true,
           graalvm20: false,
           graalvm20_1: true,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -5724,6 +5801,8 @@ exports.tests = [
           safaritp: true,
           graalvm20: false,
           graalvm20_1: true,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -5761,6 +5840,8 @@ exports.tests = [
           safaritp: true,
           graalvm20: false,
           graalvm20_1: true,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -5798,6 +5879,8 @@ exports.tests = [
           safaritp: true,
           graalvm20: false,
           graalvm20_1: true,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       }
@@ -5831,6 +5914,10 @@ exports.tests = [
       safari12: false,
       safari15: true,
       duktape2_0: false,
+      graalvm21_3_3: graalvm.esStagingFlag,
+      graalvm22_2: true,
+      hermes0_7_0: false,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -5854,6 +5941,13 @@ exports.tests = [
           && arr.at(-4) === undefined;
       */},
         res: {
+          closure: false,
+          closure20220502: {
+            val: false,
+            note_id: 'closure-at-method',
+            note_html: 'Requires native support for <code>Math.trunc</code>'
+          },
+          closure20220719: true,
           ie11: false,
           firefox68: false,
           firefox85: firefox.nightly,
@@ -5865,11 +5959,16 @@ exports.tests = [
             note_id: 'safari-at-method',
             note_html: 'The feature has to be enabled via <code>jscOptions=--useAtMethod=true</code> flag.'
           },
+          safari15_4: true,
           safaritp: true,
           duktape2_0: false,
           babel7corejs3: babel.corejs,
           typescript4corejs3: typescript.corejs,
           graalvm21: graalvm.es2022flag,
+          graalvm21_3_3: graalvm.esStagingFlag,
+          graalvm22_2: true,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -5887,6 +5986,12 @@ exports.tests = [
           && str.at(-4) === undefined;
       */},
         res: {
+          closure: false,
+          closure20220502: {
+            val: false,
+            note_id: 'closure-at-method'
+          },
+          closure20220719: true,
           ie11: false,
           firefox68: false,
           firefox85: firefox.nightly,
@@ -5897,11 +6002,16 @@ exports.tests = [
             val: 'flagged',
             note_id: 'safari-at-method'
           },
+          safari15_4: true,
           safaritp: true,
           duktape2_0: false,
           babel7corejs3: babel.corejs,
           typescript4corejs3: typescript.corejs,
           graalvm21: graalvm.es2022flag,
+          graalvm21_3_3: graalvm.esStagingFlag,
+          graalvm22_2: true,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       },
@@ -5935,6 +6045,12 @@ exports.tests = [
          });
       */},
         res: {
+          closure: false,
+          closure20220502: {
+            val: false,
+            note_id: 'closure-typed-array',
+            note_html: 'Requires native support for typed arrays'
+          },
           ie11: false,
           firefox68: false,
           firefox85: firefox.nightly,
@@ -5945,11 +6061,16 @@ exports.tests = [
             val: 'flagged',
             note_id: 'safari-at-method'
           },
+          safari15_4: true,
           safaritp: true,
           duktape2_0: false,
           babel7corejs3: babel.corejs,
           typescript4corejs3: typescript.corejs,
           graalvm21: graalvm.es2022flag,
+          graalvm21_3_3: graalvm.esStagingFlag,
+          graalvm22_2: true,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
           rhino1_7_13: false
         }
       }
@@ -5969,6 +6090,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs3: babel.corejs,
+          closure20220719: true,
           typescript3_2corejs3: typescript.corejs,
           ie11: false,
           chrome1: false,
@@ -5981,8 +6103,14 @@ exports.tests = [
           firefox92: true,
           opera10_50: false,
           safari12: false,
+          safari15_4: true,
           safaritp: true,
           duktape2_0: false,
+          graalvm21_3_3: graalvm.esStagingFlag,
+          graalvm22_2: true,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       },
@@ -5999,6 +6127,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs3: babel.corejs,
+          closure20220719: true,
           typescript3_2corejs3: typescript.corejs,
           ie11: false,
           chrome1: false,
@@ -6011,8 +6140,14 @@ exports.tests = [
           firefox92: true,
           opera10_50: false,
           safari12: false,
+          safari15_4: true,
           safaritp: true,
           duktape2_0: false,
+          graalvm21_3_3: graalvm.esStagingFlag,
+          graalvm22_2: true,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
           rhino1_7_13: false
         }
       }
@@ -6055,6 +6190,10 @@ exports.tests = [
       opera10_50: false,
       safari12: false,
       duktape2_0: false,
+      graalvm21_3_3: graalvm.esStagingFlag,
+      graalvm22_2: true,
+      hermes0_7_0: false,
+      reactnative0_70_3: false,
       rhino1_7_13: false
     },
   },
@@ -6082,6 +6221,12 @@ exports.tests = [
           safari14: false,
           safari15: true,
           duktape2_0: false,
+          graalvm21_3_3: false,
+          graalvm22_2: true,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
+          rhino1_7_14: false,
         }
       },
       {
@@ -6101,6 +6246,11 @@ exports.tests = [
           firefox91: true,
           safari14: false,
           safari15: true,
+          duktape2_0: true,
+          graalvm21_3_3: true,
+          hermes0_7_0: true,
+          reactnative0_70_3: true,
+          rhino1_7_14: true,
         }
       },
       {
@@ -6121,6 +6271,12 @@ exports.tests = [
           safari14: false,
           safari15: true,
           duktape2_0: false,
+          graalvm21_3_3: false,
+          graalvm22_2: true,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
+          rhino1_7_14: false,
         }
       },
       {
@@ -6140,6 +6296,11 @@ exports.tests = [
           firefox91: true,
           safari14: false,
           safari15: true,
+          duktape2_0: true,
+          graalvm21_3_3: true,
+          hermes0_7_0: true,
+          reactnative0_70_3: true,
+          rhino1_7_14: true,
         }
       },
       {
@@ -6160,6 +6321,12 @@ exports.tests = [
           safari14: false,
           safari15: true,
           duktape2_0: false,
+          graalvm21_3_3: false,
+          graalvm22_2: true,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
+          rhino1_7_14: false,
         }
       },
       {
@@ -6179,6 +6346,11 @@ exports.tests = [
           firefox91: true,
           safari14: false,
           safari15: true,
+          duktape2_0: true,
+          graalvm21_3_3: true,
+          hermes0_7_0: true,
+          reactnative0_70_3: true,
+          rhino1_7_14: true,
         }
       },
       {
@@ -6199,6 +6371,12 @@ exports.tests = [
           safari14: false,
           safari15: true,
           duktape2_0: false,
+          graalvm21_3_3: false,
+          graalvm22_2: true,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
+          rhino1_7_14: false,
         }
       },
       {
@@ -6218,6 +6396,11 @@ exports.tests = [
           firefox91: true,
           safari14: false,
           safari15: true,
+          duktape2_0: true,
+          graalvm21_3_3: true,
+          hermes0_7_0: true,
+          reactnative0_70_3: true,
+          rhino1_7_14: true,
         }
       },
       {
@@ -6238,6 +6421,12 @@ exports.tests = [
           safari14: false,
           safari15: true,
           duktape2_0: false,
+          graalvm21_3_3: false,
+          graalvm22_2: true,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
+          rhino1_7_14: false,
         }
       },
       {
@@ -6257,6 +6446,11 @@ exports.tests = [
           firefox91: true,
           safari14: false,
           safari15: true,
+          duktape2_0: true,
+          graalvm21_3_3: true,
+          hermes0_7_0: true,
+          reactnative0_70_3: true,
+          rhino1_7_14: true,
         }
       },
       {
@@ -6277,6 +6471,12 @@ exports.tests = [
           safari14: false,
           safari15: true,
           duktape2_0: false,
+          graalvm21_3_3: false,
+          graalvm22_2: true,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
+          rhino1_7_14: false,
         }
       },
       {
@@ -6296,6 +6496,11 @@ exports.tests = [
           firefox91: true,
           safari14: false,
           safari15: true,
+          duktape2_0: true,
+          graalvm21_3_3: true,
+          hermes0_7_0: true,
+          reactnative0_70_3: true,
+          rhino1_7_14: true,
         }
       },
       {
@@ -6316,6 +6521,12 @@ exports.tests = [
           safari14: false,
           safari15: true,
           duktape2_0: false,
+          graalvm21_3_3: false,
+          graalvm22_2: true,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
+          rhino1_7_14: false,
         }
       },
       {
@@ -6335,6 +6546,11 @@ exports.tests = [
           firefox91: true,
           safari14: false,
           safari15: true,
+          duktape2_0: true,
+          graalvm21_3_3: true,
+          hermes0_7_0: true,
+          reactnative0_70_3: true,
+          rhino1_7_14: true,
         }
       },
       {
@@ -6355,6 +6571,11 @@ exports.tests = [
           safari14: false,
           safari15: true,
           duktape2_0: false,
+          graalvm21_3_3: false,
+          graalvm22_2: true,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_14: false,
         }
       },
       {
@@ -6374,15 +6595,191 @@ exports.tests = [
           firefox91: true,
           safari14: false,
           safari15: true,
+          duktape2_0: false,
+          graalvm21_3_3: true,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_14: false,
         }
       },
     ]
-  }
+  },
+  {
+    name: 'RegExp Match Indices (`hasIndices` / `d` flag)',
+    category: '2022 features',
+    significance: 'small',
+    spec: 'https://github.com/tc39/proposal-regexp-match-indices',
+    subtests: [
+      {
+        name: 'constructor supports it',
+        exec: function () {/*
+            return new RegExp('a', 'd') instanceof RegExp;
+        */},
+        res: {
+          firefox68: false,
+          firefox78: false,
+          firefox91: true,
+          safari15: true,
+          chrome90: true,
+          graalvm21_3_3: graalvm.esStagingFlag,
+          graalvm22_2: true,
+          hermes0_7_0: false,
+          reactnative0_70_3: false
+        }
+      },
+      {
+        name: 'shows up in flags',
+        exec: function () {/*
+          var expected = ['hasIndices'];
+          // Sorted alphabetically by shortname – "dgimsuy".
+          if ('global' in RegExp.prototype) expected.push('global');
+          if ('ignoreCase' in RegExp.prototype) expected.push('ignoreCase');
+          if ('multiline' in RegExp.prototype) expected.push('multiline');
+          if ('dotAll' in RegExp.prototype) expected.push('dotAll');
+          if ('unicode' in RegExp.prototype) expected.push('unicode');
+          if ('sticky' in RegExp.prototype) expected.push('sticky');
+          var actual = [];
+          var p = new Proxy({}, { get: function(o, k) { actual.push(k); return o[k]; }});
+          Object.getOwnPropertyDescriptor(RegExp.prototype, 'flags').get.call(p);
+          if (expected.length !== actual.length) return false;
+          for (var i = 0; i < expected.length; i++) {
+            if (expected[i] !== actual[i]) return false;
+          }
+          return true;
+        */},
+        res: {
+          node16_0: false,
+          firefox68: false,
+          firefox78: false,
+          firefox91: true,
+          safari15: true,
+          chrome90: false,
+          graalvm21_3_3: graalvm.esStagingFlag,
+          graalvm22_2: true,
+          hermes0_7_0: false,
+          reactnative0_70_3: false
+        }
+      }
+    ]
+  },
+  {
+    name: 'Array find from last',
+    category: '2023 features',
+    significance: 'small',
+    spec: 'https://github.com/tc39/proposal-array-find-from-last',
+    subtests: [
+      {
+        name: "Array.prototype.findLast",
+        exec: function () {/*
+          var arr = [{ x: 1 }, { x: 2 }, { x: 1 }, { x: 2 }];
+          return arr.findLast(function (o) { return o.x === 1; }) === arr[2];
+        */},
+        res: {
+          babel7corejs3: babel.corejs,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          chrome1: false,
+          chrome90: false,
+          chrome96: false,
+          chrome97: true,
+          edge18: false,
+          firefox2: false,
+          firefox89: false,
+          firefox102: false,
+          firefox103: {
+            val: 'flagged',
+            note_id: 'firefox-arrayfindfromlast',
+            note_html: 'The feature has to be enabled via <code>javascript.options.experimental.array_find_last</code> setting under <code>about:config</code>.'
+          },
+          firefox104: true,
+          opera10_50: false,
+          safari12: false,
+          safari15_4: true,
+          safaritp: true,
+          duktape2_0: false,
+          graalvm21_3_3: false,
+          graalvm22_2: graalvm.esStagingFlag,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: "Array.prototype.findLastIndex",
+        exec: function () {/*
+          var arr = [{ x: 1 }, { x: 2 }, { x: 1 }, { x: 2 }];
+          return arr.findLastIndex(function (o) { return o.x === 1; }) === 2;
+        */},
+        res: {
+          babel7corejs3: babel.corejs,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          chrome1: false,
+          chrome90: false,
+          chrome96: false,
+          chrome97: true,
+          edge18: false,
+          firefox2: false,
+          firefox89: false,
+          firefox102: false,
+          firefox103: { val: 'flagged', note_id: 'firefox-arrayfindfromlast' },
+          firefox104: true,
+          opera10_50: false,
+          safari12: false,
+          safari15_4: true,
+          safaritp: true,
+          duktape2_0: false,
+          graalvm21_3_3: false,
+          graalvm22_2: graalvm.esStagingFlag,
+          hermes0_7_0: false,
+          hermes0_12_0: true,
+          reactnative0_70_3: true,
+          rhino1_7_13: false
+        }
+      }
+    ]
+  },
+  {
+    name: 'Hashbang Grammar',
+    category: '2023 features',
+    significance: 'tiny',
+    spec: 'https://github.com/tc39/proposal-hashbang/',
+    mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Hashbang_comments',
+    exec: function() {/*
+      try {
+        return !eval('#!/wash/your/hands');
+      } catch (e) {
+        return false
+      }
+    */},
+    res: {
+      chrome1: false,
+      chrome74: true,
+      firefox2: false,
+      firefox67: true,
+      ie11: false,
+      opera10_50: false,
+      edge18: false,
+      safari1: false,
+      safari13: false,
+      safari13_1: true,
+      duktape2_0: false,
+      graalvm19: false,
+      graalvm20_1: true,
+      babel7corejs3: false,
+      typescript3_2corejs3: false,
+      closure: false,
+      hermes0_7_0: true,
+      reactnative0_70_3: true,
+      rhino1_7_13: false
+    }
+  },
 ];
 
 //Shift annex B features to the bottom
 exports.tests = exports.tests.reduce(function(a,e) {
-  var index = ['2016 features', '2016 misc', '2017 features', '2017 misc', '2017 annex b', '2018 features', '2018 misc', '2019 features', '2019 misc', '2020 features', '2021 features', '2022 features', 'finished (stage 4)'].indexOf(e.category);
+  var index = ['2016 features', '2016 misc', '2017 features', '2017 misc', '2017 annex b', '2018 features', '2018 misc', '2019 features', '2019 misc', '2020 features', '2021 features', '2022 features', '2023 features', 'finished (stage 4)'].indexOf(e.category);
   if (index === -1) {
     console.log('"' + a.category + '" is not an ES2016+ category!');
   }

--- a/test/ecmascript/data-es5.js
+++ b/test/ecmascript/data-es5.js
@@ -32,10 +32,9 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -61,10 +60,9 @@ exports.tests = [
       nashorn1_8: true,
       nashorn9: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -90,10 +88,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -119,10 +116,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -152,10 +148,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   }],
   separator: 'after'
@@ -187,10 +182,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -229,10 +223,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -259,10 +252,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -291,10 +283,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -324,10 +315,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -354,10 +344,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -384,10 +373,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -414,10 +402,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -444,10 +431,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -474,10 +460,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -504,10 +489,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -542,10 +526,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -574,10 +557,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     },
     separator: 'after'
   }],
@@ -585,401 +567,418 @@ exports.tests = [
 {
   name: 'Array methods',
   significance: 'large',
-  subtests: [{
-    name: 'Array.isArray',
-    mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray',
-    exec: function () {
-      return typeof Array.isArray === 'function';
-    },
-    res: {
-      es5shim: true,
-      ie9: true,
-      firefox2: false,
-      firefox4: true,
-      safari4: true,
-      chrome5: true,
-      opera10_50: true,
-      konq4_3: false,
-      konq4_9: true,
-      konq4_13: true,
-      besen: true,
-      rhino1_7_13: true,
-      ejs: true,
-      android4_0: true,
-      duktape2_0: true,
-      nashorn1_8: true,
-      nashorn9: true,
-      nashorn10: true,
-      graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
-      jerryscript1_0: true,
-      hermes0_7_0: true
-    }
-  },
-  {
-    name: 'Array.prototype.indexOf',
-    mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf',
-    exec: function () {
-      return typeof Array.prototype.indexOf === 'function';
-    },
-    res: {
-      es5shim: true,
-      ie9: true,
-      firefox2: true,
-      safari3_1: true,
-      chrome5: true,
-      opera10_10: true,
-      opera10_50: true,
-      konq4_3: true,
-      besen: true,
-      rhino1_7_13: true,
-      ejs: true,
-      android4_0: true,
-      duktape2_0: true,
-      nashorn1_8: true,
-      nashorn9: true,
-      nashorn10: true,
-      graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
-      jerryscript1_0: true,
-      hermes0_7_0: true
-    }
-  },
-  {
-    name: 'Array.prototype.lastIndexOf',
-    mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf',
-    exec: function () {
-      return typeof Array.prototype.lastIndexOf === 'function';
-    },
-    res: {
-      es5shim: true,
-      ie9: true,
-      firefox2: true,
-      safari3_1: true,
-      chrome5: true,
-      opera10_10: true,
-      opera10_50: true,
-      konq4_3: true,
-      besen: true,
-      rhino1_7_13: true,
-      ejs: true,
-      android4_0: true,
-      duktape2_0: true,
-      nashorn1_8: true,
-      nashorn9: true,
-      nashorn10: true,
-      graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
-      jerryscript1_0: true,
-      hermes0_7_0: true
-    }
-  },
-  {
-    name: 'Array.prototype.every',
-    mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every',
-    exec: function () {
-      return typeof Array.prototype.every === 'function';
-    },
-    res: {
-      es5shim: sparseNote,
-      ie9: true,
-      firefox2: true,
-      safari3_1: true,
-      chrome5: true,
-      opera10_10: true,
-      opera10_50: true,
-      konq4_3: true,
-      besen: true,
-      rhino1_7_13: true,
-      ejs: true,
-      android4_0: true,
-      duktape2_0: true,
-      nashorn1_8: true,
-      nashorn9: true,
-      nashorn10: true,
-      graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
-      jerryscript1_0: true,
-      hermes0_7_0: true
-    }
-  },
-  {
-    name: 'Array.prototype.some',
-    mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some',
-    exec: function () {
-      return typeof Array.prototype.some === 'function';
-    },
-    res: {
-      es5shim: sparseNote,
-      ie9: true,
-      firefox2: true,
-      safari3_1: true,
-      chrome5: true,
-      opera10_10: true,
-      opera10_50: true,
-      konq4_3: true,
-      besen: true,
-      rhino1_7_13: true,
-      ejs: true,
-      android4_0: true,
-      duktape2_0: true,
-      nashorn1_8: true,
-      nashorn9: true,
-      nashorn10: true,
-      graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
-      jerryscript1_0: true,
-      hermes0_7_0: true
-    }
-  },
-  {
-    name: 'Array.prototype.forEach',
-    mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach',
-    exec: function () {
-      return typeof Array.prototype.forEach === 'function';
-    },
-    res: {
-      es5shim: sparseNote,
-      ie9: true,
-      firefox2: true,
-      safari3_1: true,
-      chrome5: true,
-      opera10_10: true,
-      opera10_50: true,
-      konq4_3: true,
-      besen: true,
-      rhino1_7_13: true,
-      ejs: true,
-      android4_0: true,
-      duktape2_0: true,
-      nashorn1_8: true,
-      nashorn9: true,
-      nashorn10: true,
-      graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
-      jerryscript1_0: true,
-      hermes0_7_0: true
-    }
-  },
-  {
-    name: 'Array.prototype.map',
-    mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map',
-    exec: function () {
-      return typeof Array.prototype.map === 'function';
-    },
-    res: {
-      es5shim: sparseNote,
-      ie9: true,
-      firefox2: true,
-      safari3_1: true,
-      chrome5: true,
-      opera10_10: true,
-      opera10_50: true,
-      konq4_3: true,
-      besen: true,
-      rhino1_7_13: true,
-      ejs: true,
-      android4_0: true,
-      duktape2_0: true,
-      nashorn1_8: true,
-      nashorn9: true,
-      nashorn10: true,
-      graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
-      jerryscript1_0: true,
-      hermes0_7_0: true
-    }
-  },
-  {
-    name: 'Array.prototype.filter',
-    mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter',
-    exec: function () {
-      return typeof Array.prototype.filter === 'function';
-    },
-    res: {
-      es5shim: sparseNote,
-      ie9: true,
-      firefox2: true,
-      safari3_1: true,
-      chrome5: true,
-      opera10_10: true,
-      opera10_50: true,
-      konq4_3: true,
-      besen: true,
-      rhino1_7_13: true,
-      ejs: true,
-      android4_0: true,
-      duktape2_0: true,
-      nashorn1_8: true,
-      nashorn9: true,
-      nashorn10: true,
-      graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
-      jerryscript1_0: true,
-      hermes0_7_0: true
-    }
-  },
-  {
-    name: 'Array.prototype.reduce',
-    mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce',
-    exec: function () {
-      return typeof Array.prototype.reduce === 'function';
-    },
-    res: {
-      es5shim: sparseNote,
-      ie9: true,
-      firefox2: false,
-      firefox3: true,
-      safari4: true,
-      chrome5: true,
-      opera10_50: true,
-      konq4_3: true,
-      besen: true,
-      rhino1_7_13: true,
-      ejs: true,
-      android4_0: true,
-      duktape2_0: true,
-      nashorn1_8: true,
-      nashorn9: true,
-      nashorn10: true,
-      graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
-      jerryscript1_0: true,
-      hermes0_7_0: true
-    }
-  },
-  {
-    name: 'Array.prototype.reduceRight',
-    mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduceRight',
-    exec: function () {
-      return typeof Array.prototype.reduceRight === 'function';
-    },
-    res: {
-      es5shim: sparseNote,
-      ie9: true,
-      firefox2: false,
-      firefox3: true,
-      safari4: true,
-      chrome5: true,
-      opera10_50: true,
-      konq4_3: true,
-      besen: true,
-      rhino1_7_13: true,
-      ejs: true,
-      android4_0: true,
-      duktape2_0: true,
-      nashorn1_8: true,
-      nashorn9: true,
-      nashorn10: true,
-      graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
-      jerryscript1_0: true,
-      hermes0_7_0: true
-    }
-  }, {
-    name: 'Array.prototype.sort: compareFn must be function or undefined',
-    exec: function () {
-      try {
-        [1,2].sort(null);
-        return false;
-      } catch (enull) {}
-      try {
-        [1,2].sort(true);
-        return false;
-      } catch (etrue) {}
-      try {
-        [1,2].sort({});
-        return false;
-      } catch (eobj) {}
-      try {
-        [1,2].sort([]);
-        return false;
-      } catch (earr) {}
-      try {
-        [1,2].sort(/a/g);
-        return false;
-      } catch (eregex) {}
-      return true;
-    },
-    res: {
-      es5shim: true,
-      ie9: true,
-      firefox2: false,
-      firefox5: true,
-      safari1: false,
-      safari10_1: true,
-      safari11: false,
-      safari12: true,
-      safaritp: true,
-      chrome1: false,
-      chrome63: true,
-      opera10_10: null,
-      opera10_50: true,
-      konq4_3: null,
-      konq4_9: null,
-      konq4_13: null,
-      besen: null,
-      rhino1_7_13: true,
-      ejs: null,
-      android4_0: false,
-      duktape2_0: true,
-      nashorn1_8: true,
-      nashorn9: true,
-      nashorn10: true,
-      graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
-      jerryscript1_0: true,
-      hermes0_7_0: true
-    }
-  },
-  {
-    name: 'Array.prototype.sort: compareFn may be explicit undefined',
-    exec: function () {
-      try {
-        var arr = [2, 1];
-        return arr.sort(undefined) === arr && arr[0] === 1 && arr[1] === 2;
-      } catch (e) {
-        return false;
+  subtests: [
+    {
+      name: 'Array.isArray',
+      mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray',
+      exec: function () {
+        return typeof Array.isArray === 'function';
+      },
+      res: {
+        es5shim: true,
+        ie9: true,
+        firefox2: false,
+        firefox4: true,
+        safari4: true,
+        chrome5: true,
+        opera10_50: true,
+        konq4_3: false,
+        konq4_9: true,
+        konq4_13: true,
+        besen: true,
+        rhino1_7_13: true,
+        ejs: true,
+        android4_0: true,
+        duktape2_0: true,
+        nashorn1_8: true,
+        nashorn9: true,
+        nashorn10: true,
+        graalvm19: true,
+        jerryscript1_0: true,
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
-    res: {
-      es5shim: true,
-      ie9: true,
-      firefox2: false,
-      firefox4: true,
-      safari3_1: true,
-      chrome13: true,
-      opera10_10: null,
-      opera10_50: true,
-      konq4_3: null,
-      konq4_9: null,
-      konq4_13: null,
-      besen: null,
-      rhino1_7_13: true,
-      ejs: null,
-      android4_0: true,
-      duktape2_0: true,
-      nashorn1_8: true,
-      nashorn9: true,
-      nashorn10: true,
-      graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
-      jerryscript1_0: true,
-      hermes0_7_0: true
+    {
+      name: 'Array.prototype.indexOf',
+      mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf',
+      exec: function () {
+        return typeof Array.prototype.indexOf === 'function';
+      },
+      res: {
+        es5shim: true,
+        ie9: true,
+        firefox2: true,
+        safari3_1: true,
+        chrome5: true,
+        opera10_10: true,
+        opera10_50: true,
+        konq4_3: true,
+        besen: true,
+        rhino1_7_13: true,
+        ejs: true,
+        android4_0: true,
+        duktape2_0: true,
+        nashorn1_8: true,
+        nashorn9: true,
+        nashorn10: true,
+        graalvm19: true,
+        jerryscript1_0: true,
+        hermes0_7_0: true,
+        reactnative0_70_3: true
+      }
+    },
+    {
+      name: 'Array.prototype.lastIndexOf',
+      mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf',
+      exec: function () {
+        return typeof Array.prototype.lastIndexOf === 'function';
+      },
+      res: {
+        es5shim: true,
+        ie9: true,
+        firefox2: true,
+        safari3_1: true,
+        chrome5: true,
+        opera10_10: true,
+        opera10_50: true,
+        konq4_3: true,
+        besen: true,
+        rhino1_7_13: true,
+        ejs: true,
+        android4_0: true,
+        duktape2_0: true,
+        nashorn1_8: true,
+        nashorn9: true,
+        nashorn10: true,
+        graalvm19: true,
+        jerryscript1_0: true,
+        hermes0_7_0: true,
+        reactnative0_70_3: true
+      }
+    },
+    {
+      name: 'Array.prototype.every',
+      mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every',
+      exec: function () {
+        return typeof Array.prototype.every === 'function';
+      },
+      res: {
+        es5shim: sparseNote,
+        ie9: true,
+        firefox2: true,
+        safari3_1: true,
+        chrome5: true,
+        opera10_10: true,
+        opera10_50: true,
+        konq4_3: true,
+        besen: true,
+        rhino1_7_13: true,
+        ejs: true,
+        android4_0: true,
+        duktape2_0: true,
+        nashorn1_8: true,
+        nashorn9: true,
+        nashorn10: true,
+        graalvm19: true,
+        jerryscript1_0: true,
+        hermes0_7_0: true,
+        reactnative0_70_3: true
+      }
+    },
+    {
+      name: 'Array.prototype.some',
+      mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some',
+      exec: function () {
+        return typeof Array.prototype.some === 'function';
+      },
+      res: {
+        es5shim: sparseNote,
+        ie9: true,
+        firefox2: true,
+        safari3_1: true,
+        chrome5: true,
+        opera10_10: true,
+        opera10_50: true,
+        konq4_3: true,
+        besen: true,
+        rhino1_7_13: true,
+        ejs: true,
+        android4_0: true,
+        duktape2_0: true,
+        nashorn1_8: true,
+        nashorn9: true,
+        nashorn10: true,
+        graalvm19: true,
+        jerryscript1_0: true,
+        hermes0_7_0: true,
+        reactnative0_70_3: true
+      }
+    },
+    {
+      name: 'Array.prototype.forEach',
+      mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach',
+      exec: function () {
+        return typeof Array.prototype.forEach === 'function';
+      },
+      res: {
+        es5shim: sparseNote,
+        ie9: true,
+        firefox2: true,
+        safari3_1: true,
+        chrome5: true,
+        opera10_10: true,
+        opera10_50: true,
+        konq4_3: true,
+        besen: true,
+        rhino1_7_13: true,
+        ejs: true,
+        android4_0: true,
+        duktape2_0: true,
+        nashorn1_8: true,
+        nashorn9: true,
+        nashorn10: true,
+        graalvm19: true,
+        jerryscript1_0: true,
+        hermes0_7_0: true,
+        reactnative0_70_3: true
+      }
+    },
+    {
+      name: 'Array.prototype.map',
+      mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map',
+      exec: function () {
+        return typeof Array.prototype.map === 'function';
+      },
+      res: {
+        es5shim: sparseNote,
+        ie9: true,
+        firefox2: true,
+        safari3_1: true,
+        chrome5: true,
+        opera10_10: true,
+        opera10_50: true,
+        konq4_3: true,
+        besen: true,
+        rhino1_7_13: true,
+        ejs: true,
+        android4_0: true,
+        duktape2_0: true,
+        nashorn1_8: true,
+        nashorn9: true,
+        nashorn10: true,
+        graalvm19: true,
+        jerryscript1_0: true,
+        hermes0_7_0: true,
+        reactnative0_70_3: true
+      }
+    },
+    {
+      name: 'Array.prototype.filter',
+      mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter',
+      exec: function () {
+        return typeof Array.prototype.filter === 'function';
+      },
+      res: {
+        es5shim: sparseNote,
+        ie9: true,
+        firefox2: true,
+        safari3_1: true,
+        chrome5: true,
+        opera10_10: true,
+        opera10_50: true,
+        konq4_3: true,
+        besen: true,
+        rhino1_7_13: true,
+        ejs: true,
+        android4_0: true,
+        duktape2_0: true,
+        nashorn1_8: true,
+        nashorn9: true,
+        nashorn10: true,
+        graalvm19: true,
+        jerryscript1_0: true,
+        hermes0_7_0: true,
+        reactnative0_70_3: true
+      }
+    },
+    {
+      name: 'Array.prototype.reduce',
+      mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce',
+      exec: function () {
+        return typeof Array.prototype.reduce === 'function';
+      },
+      res: {
+        es5shim: sparseNote,
+        ie9: true,
+        firefox2: false,
+        firefox3: true,
+        safari4: true,
+        chrome5: true,
+        opera10_50: true,
+        konq4_3: true,
+        besen: true,
+        rhino1_7_13: true,
+        ejs: true,
+        android4_0: true,
+        duktape2_0: true,
+        nashorn1_8: true,
+        nashorn9: true,
+        nashorn10: true,
+        graalvm19: true,
+        jerryscript1_0: true,
+        hermes0_7_0: true,
+        reactnative0_70_3: true
+      }
+    },
+    {
+      name: 'Array.prototype.reduceRight',
+      mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduceRight',
+      exec: function () {
+        return typeof Array.prototype.reduceRight === 'function';
+      },
+      res: {
+        es5shim: sparseNote,
+        ie9: true,
+        firefox2: false,
+        firefox3: true,
+        safari4: true,
+        chrome5: true,
+        opera10_50: true,
+        konq4_3: true,
+        besen: true,
+        rhino1_7_13: true,
+        ejs: true,
+        android4_0: true,
+        duktape2_0: true,
+        nashorn1_8: true,
+        nashorn9: true,
+        nashorn10: true,
+        graalvm19: true,
+        jerryscript1_0: true,
+        hermes0_7_0: true,
+        reactnative0_70_3: true
+      }
+    },
+    {
+      name: 'Array.prototype.sort: compareFn must be function or undefined',
+      exec: function () {
+        try {
+          [1,2].sort(null);
+          return false;
+        } catch (enull) {}
+        try {
+          [1,2].sort(true);
+          return false;
+        } catch (etrue) {}
+        try {
+          [1,2].sort({});
+          return false;
+        } catch (eobj) {}
+        try {
+          [1,2].sort([]);
+          return false;
+        } catch (earr) {}
+        try {
+          [1,2].sort(/a/g);
+          return false;
+        } catch (eregex) {}
+        return true;
+      },
+      res: {
+        es5shim: true,
+        ie9: true,
+        firefox2: false,
+        firefox5: true,
+        safari1: false,
+        safari10_1: true,
+        safari11: false,
+        safari12: true,
+        safaritp: true,
+        chrome1: false,
+        chrome63: true,
+        opera10_10: null,
+        opera10_50: true,
+        konq4_3: null,
+        konq4_9: null,
+        konq4_13: null,
+        besen: null,
+        rhino1_7_13: true,
+        ejs: null,
+        android4_0: false,
+        duktape2_0: true,
+        nashorn1_8: true,
+        nashorn9: true,
+        nashorn10: true,
+        graalvm19: true,
+        jerryscript1_0: true,
+        hermes0_7_0: true,
+        reactnative0_70_3: true
+      }
+    },
+    {
+      name: 'Array.prototype.sort: compareFn may be explicit undefined',
+      exec: function () {
+        try {
+          var arr = [2, 1];
+          return arr.sort(undefined) === arr && arr[0] === 1 && arr[1] === 2;
+        } catch (e) {
+          return false;
+        }
+      },
+      res: {
+        es5shim: true,
+        ie9: true,
+        firefox2: false,
+        firefox4: true,
+        safari3_1: true,
+        chrome13: true,
+        opera10_10: null,
+        opera10_50: true,
+        konq4_3: null,
+        konq4_9: null,
+        konq4_13: null,
+        besen: null,
+        rhino1_7_13: true,
+        ejs: null,
+        android4_0: true,
+        duktape2_0: true,
+        nashorn1_8: true,
+        nashorn9: true,
+        nashorn10: true,
+        graalvm19: true,
+        jerryscript1_0: true,
+        hermes0_7_0: true,
+        reactnative0_70_3: true
+      }
+    },
+    {
+      name: 'Array.prototype.unshift: [].unshift(0) returns the unshifted count',
+      exec: function () {
+        return [].unshift(0) === 1;
+      },
+      res: {
+        es5shim: true,
+        chrome15: true,
+        chrome101: true,
+        firefox3: true,
+        firefox100: true,
+        ie6: false,
+        ie7: false,
+        ie8: true,
+        ie11: true,
+        opera10_60: true,
+        opera11: true,
+        opera12_10: true,
+        opera12: true,
+        safari4: true,
+        safari15: true,
+        graalvm21_3_3: true,
+        hermes0_7_0: true,
+        reactnative0_70_3: true
+      }
     }
-  }],
+  ],
 },
 {
   name: 'String properties and methods',
@@ -1008,10 +1007,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1062,7 +1060,28 @@ exports.tests = [
       jerryscript1_0: false,
       jerryscript2_2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
+    }
+  },
+  {
+    name: 'String.prototype.substr',
+    mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr',
+    exec: function () {
+      return '0b'.substr(-1) === 'b';
+    },
+    res: {
+      es5shim: true,
+      ie6: false,
+      ie7: false,
+      ie8: false,
+      ie9: true,
+      chrome15: true,
+      firefox3: true,
+      opera11: true,
+      graalvm21_3_3: true,
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1091,10 +1110,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     },
     separator: 'after'
   }
@@ -1127,10 +1145,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1156,10 +1173,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1197,10 +1213,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   }]
 },
@@ -1223,7 +1238,7 @@ exports.tests = [
     konq4_13: true,
     besen: true,
     rhino1_7_13: true,
-    phantom: true,
+    phantom1_9: true,
     ejs: true,
     ios7: true,
     android4_0: true,
@@ -1232,10 +1247,9 @@ exports.tests = [
     nashorn9: true,
     nashorn10: true,
     graalvm19: true,
-    graalvm20: true,
-    graalvm20_1: true,
     jerryscript1_0: true,
-    hermes0_7_0: true
+    hermes0_7_0: true,
+    reactnative0_70_3: true
   },
 },
 {
@@ -1260,7 +1274,7 @@ exports.tests = [
     konq4_13: true,
     besen: true,
     rhino1_7_13: true,
-    phantom: true,
+    phantom1_9: true,
     ejs: true,
     ios7: true,
     android4_0: true,
@@ -1269,10 +1283,9 @@ exports.tests = [
     nashorn9: true,
     nashorn10: true,
     graalvm19: true,
-    graalvm20: true,
-    graalvm20_1: true,
     jerryscript1_0: true,
-    hermes0_7_0: true
+    hermes0_7_0: true,
+    reactnative0_70_3: true
   },
   separator: 'after'
 },
@@ -1309,10 +1322,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1344,10 +1356,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1379,10 +1390,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   }]
 },
@@ -1417,7 +1427,11 @@ exports.tests = [
       edge17: false,
       edge18: true,
       edge80: true,
-      duktape2_0: true
+      duktape2_0: true,
+      graalvm21_3_3: true,
+      hermes0_7_0: true,
+      reactnative0_70_3: true,
+      rhino1_7_14: true,
     }
   }, {
     name: 'Number.prototype.toExponential throws on ±Infinity fractionDigits',
@@ -1446,7 +1460,11 @@ exports.tests = [
       edge17: true,
       edge18: true,
       edge80: true,
-      duktape2_0: true
+      duktape2_0: true,
+      graalvm21_3_3: true,
+      hermes0_7_0: true,
+      reactnative0_70_3: true,
+      rhino1_7_14: true,
     }
   }, {
     name: 'Number.prototype.toExponential does not throw on edge cases',
@@ -1467,9 +1485,14 @@ exports.tests = [
       firefox50: true,
       ie6: true,
       ie8: true,
-      edge11: true,
+      edge12: true,
       safari10: false,
-      safari11: true
+      safari11: true,
+      duktape2_0: true,
+      graalvm21_3_3: true,
+      hermes0_7_0: true,
+      reactnative0_70_3: true,
+      rhino1_7_14: true,
     }
   }],
 },
@@ -1506,10 +1529,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1538,10 +1560,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1570,10 +1591,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1603,10 +1623,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1639,11 +1658,10 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: false,
       jerryscript2_2_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1672,10 +1690,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   },
   {
@@ -1714,11 +1731,10 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: false,
       jerryscript2_0: true,
-      hermes0_7_0: false
+      hermes0_7_0: false,
+      reactnative0_70_3: false
     }
   },
   {
@@ -1750,10 +1766,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
-      hermes0_7_0: true
+      hermes0_7_0: true,
+      reactnative0_70_3: true
     }
   }]
 },
@@ -1780,7 +1795,7 @@ exports.tests = [
       opera10_50: false,
       opera12: true,
       besen: true,
-      phantom: true,
+      phantom1_9: true,
       ejs: true,
       ios7: true,
       android4_1: true,
@@ -1789,10 +1804,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalStrictMode,
+      reactnative0_70_3: false,
       rhino1_7_13: true
     }
   },
@@ -1814,7 +1828,7 @@ exports.tests = [
       opera10_50: false,
       opera12: true,
       besen: true,
-      phantom: true,
+      phantom1_9: true,
       ejs: true,
       ios7: true,
       android4_1: true,
@@ -1823,10 +1837,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -1846,7 +1859,7 @@ exports.tests = [
       opera10_50: false,
       opera12: true,
       besen: true,
-      phantom: true,
+      phantom1_9: true,
       ejs: true,
       ios7: true,
       android4_1: true,
@@ -1855,10 +1868,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -1893,17 +1905,16 @@ exports.tests = [
       opera10_50: false,
       opera12_10: true,
       besen: true,
-      phantom: true,
+      phantom1_9: true,
       ejs: true,
       ios7: true,
       android4_1: true,
       duktape2_0: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: false,
       jerryscript2_3_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -1924,7 +1935,7 @@ exports.tests = [
       opera10_50: false,
       opera12: true,
       besen: true,
-      phantom: true,
+      phantom1_9: true,
       ejs: true,
       ios7: true,
       android4_1: true,
@@ -1933,10 +1944,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalStrictMode,
+      reactnative0_70_3: false,
       rhino1_7_13: false
     }
   },
@@ -1955,7 +1965,7 @@ exports.tests = [
       opera10_50: false,
       opera12: true,
       besen: true,
-      phantom: true,
+      phantom1_9: true,
       ejs: true,
       ios7: true,
       android4_1: true,
@@ -1964,10 +1974,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalStrictMode,
+      reactnative0_70_3: false,
       rhino1_7_13: true
     }
   },
@@ -1990,7 +1999,7 @@ exports.tests = [
       opera10_50: false,
       opera12: true,
       besen: true,
-      phantom: true,
+      phantom1_9: true,
       ejs: true,
       ios7: true,
       android4_1: true,
@@ -1999,10 +2008,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalStrictMode,
+      reactnative0_70_3: false,
       rhino1_7_13: false
     }
   },
@@ -2025,17 +2033,16 @@ exports.tests = [
       opera10_50: false,
       opera12: true,
       besen: true,
-      phantom: true,
+      phantom1_9: true,
       ejs: true,
       ios7: true,
       android4_1: true,
       duktape2_0: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: false,
       jerryscript2_0: true,
       hermes0_7_0: false,
+      reactnative0_70_3: false,
       rhino1_7_13: false
     }
   },
@@ -2060,7 +2067,7 @@ exports.tests = [
       opera10_50: false,
       opera12: true,
       besen: true,
-      phantom: true,
+      phantom1_9: true,
       ejs: true,
       ios7: true,
       android4_1: true,
@@ -2069,10 +2076,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalStrictMode,
+      reactnative0_70_3: false,
       rhino1_7_13: true
     }
   },
@@ -2094,7 +2100,7 @@ exports.tests = [
       opera10_50: true,
       opera12: true,
       besen: true,
-      phantom: true,
+      phantom1_9: true,
       ejs: true,
       ios7: true,
       android4_1: true,
@@ -2103,10 +2109,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: true
     }
   },
@@ -2126,7 +2131,7 @@ exports.tests = [
       opera10_50: false,
       opera12: true,
       besen: true,
-      phantom: true,
+      phantom1_9: true,
       ejs: true,
       ios7: true,
       android4_1: true,
@@ -2135,10 +2140,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: true
     }
   },
@@ -2159,7 +2163,7 @@ exports.tests = [
       opera10_50: false,
       opera12: true,
       besen: true,
-      phantom: true,
+      phantom1_9: true,
       ejs: true,
       ios7: true,
       android4_1: true,
@@ -2168,10 +2172,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -2196,7 +2199,7 @@ exports.tests = [
       opera10_50: false,
       opera12: true,
       besen: true,
-      phantom: true,
+      phantom1_9: true,
       ejs: true,
       ios7: true,
       android4_1: true,
@@ -2205,10 +2208,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: true
     }
   },
@@ -2227,7 +2229,7 @@ exports.tests = [
       opera10_50: false,
       opera12: true,
       besen: true,
-      phantom: true,
+      phantom1_9: true,
       ejs: true,
       ios7: true,
       android4_1: true,
@@ -2236,10 +2238,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalLexicalScopeSuccess,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }
   },
@@ -2258,7 +2259,7 @@ exports.tests = [
       opera10_50: false,
       opera12: true,
       besen: true,
-      phantom: true,
+      phantom1_9: true,
       ejs: true,
       ios7: true,
       android4_1: true,
@@ -2267,10 +2268,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalStrictMode,
+      reactnative0_70_3: false,
       rhino1_7_13: false
     }
   },
@@ -2289,7 +2289,7 @@ exports.tests = [
       opera10_50: false,
       opera12: true,
       besen: true,
-      phantom: true,
+      phantom1_9: true,
       ejs: true,
       ios7: true,
       android4_1: true,
@@ -2298,10 +2298,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: true
     }
   },
@@ -2320,7 +2319,7 @@ exports.tests = [
       opera10_50: false,
       opera12: true,
       besen: true,
-      phantom: true,
+      phantom1_9: true,
       ejs: true,
       ios7: true,
       android4_1: true,
@@ -2329,10 +2328,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: true
     }
   },
@@ -2351,7 +2349,7 @@ exports.tests = [
       opera10_50: false,
       opera12: true,
       besen: true,
-      phantom: true,
+      phantom1_9: true,
       ejs: true,
       ios7: true,
       android4_1: true,
@@ -2360,10 +2358,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalStrictMode,
+      reactnative0_70_3: false,
       rhino1_7_13: true
     }
   },
@@ -2385,7 +2382,7 @@ exports.tests = [
       opera10_50: true,
       opera12: true,
       besen: true,
-      phantom: true,
+      phantom1_9: true,
       ejs: true,
       ios7: true,
       ios8: true,
@@ -2396,11 +2393,10 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript1_0: false,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: true
     }
   }]

--- a/test/ecmascript/data-es6.js
+++ b/test/ecmascript/data-es6.js
@@ -5,6 +5,7 @@ var typescript = common.typescript;
 var chrome = common.chrome;
 var edge = common.edge;
 var safari = common.safari;
+var graalvm = common.graalvm;
 var hermes = common.hermes;
 
 exports.name = 'ES6';
@@ -17,6 +18,16 @@ exports.tests = [
   category: 'optimisation',
   significance: 'medium',
   spec: 'http://www.ecma-international.org/ecma-262/6.0/#sec-tail-position-calls',
+  note_id: 'proper-tail-calls',
+  note_html: '<a href="https://www.stefanjudis.com/today-i-learned/proper-tail-calls-in-javascript/">'
+    + 'The feature can be enabled with <code>use strict</code> and JavaScript flag <code>"--harmony-tailcalls"</code></a> '
+    + 'in certain versions of Node.js. Since Node.js 8.2.1, the V8 flags '
+    + '<code>--harmony-tailcalls</code> and <code>--harmony-explicit-tailcalls</code> '
+    + 'have been removed. See: '
+    + '<a href="https://www.chromestatus.com/feature/5516876633341952">Chrome Platform Status</a>, '
+    + '<a href="https://javascript.plainenglish.io/tail-calls-in-javascript-will-there-be-a-comeback-63ac3a0523a5">'
+    + 'blog in JavaScript in Plain English</a>, '
+    + 'and <a href="https://v8.dev/blog/modern-javascript#proper-tail-calls">V8 Dev Blog</a> for details.',
   subtests: [
     {
       name: 'direct recursion',
@@ -47,10 +58,9 @@ exports.tests = [
         xs6: true,
         duktape2_0: true,
         graalvm19: false,
-        graalvm20: false,
-        graalvm20_1: false,
         jerryscript2_0: false,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: true
       }
     },
@@ -85,10 +95,9 @@ exports.tests = [
         xs6: true,
         duktape2_0: true,
         graalvm19: false,
-        graalvm20: false,
-        graalvm20_1: false,
         jerryscript2_0: false,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: true
       }
     }
@@ -130,10 +139,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -167,10 +175,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -204,10 +211,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -237,10 +243,9 @@ exports.tests = [
         xs6: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -270,10 +275,9 @@ exports.tests = [
         xs6: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -303,10 +307,9 @@ exports.tests = [
         xs6: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -336,11 +339,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -369,10 +371,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -400,11 +401,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -428,11 +428,10 @@ exports.tests = [
         xs6: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: true
       }
     },
@@ -474,11 +473,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -518,10 +516,9 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -546,11 +543,10 @@ exports.tests = [
         duktape2_0: false,
         duktape2_2: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -594,11 +590,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -632,11 +627,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -672,11 +666,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -713,11 +706,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -753,11 +745,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -791,11 +782,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -828,11 +818,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -865,11 +854,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -900,11 +888,11 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        hermes0_12_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -941,11 +929,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -980,11 +967,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1021,11 +1007,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1063,11 +1048,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1092,7 +1076,7 @@ exports.tests = [
         firefox2: false,
         firefox7: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome41: true,
         safari10: true,
         node0_12: "flagged",
@@ -1104,11 +1088,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1143,11 +1126,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1181,11 +1163,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1219,11 +1200,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1255,11 +1235,11 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        hermes0_12_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -1305,11 +1285,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -1343,11 +1322,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -1383,11 +1361,10 @@ exports.tests = [
         xs6: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -1424,11 +1401,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1462,11 +1438,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -1497,11 +1472,11 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        hermes0_12_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1541,11 +1516,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1582,9 +1556,8 @@ exports.tests = [
         duktape2_0: false,
         jerryscript2_2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -1618,11 +1591,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -1657,11 +1629,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -1698,11 +1669,10 @@ exports.tests = [
         xs6: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -1740,11 +1710,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1779,11 +1748,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -1815,11 +1783,11 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        hermes0_12_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1860,11 +1828,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1901,9 +1868,8 @@ exports.tests = [
         duktape2_0: false,
         jerryscript2_2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -1944,10 +1910,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -1979,10 +1944,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2014,10 +1978,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2053,11 +2016,10 @@ exports.tests = [
         xs6: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2093,11 +2055,10 @@ exports.tests = [
         node6_5: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -2128,11 +2089,10 @@ exports.tests = [
         xs6: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2162,10 +2122,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         jerryscript2_2_0: true,
         rhino1_7_13: false
       }
@@ -2208,10 +2167,9 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2241,10 +2199,9 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2280,11 +2237,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2319,11 +2275,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2350,10 +2305,9 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -2393,11 +2347,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2426,11 +2379,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2462,11 +2414,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2492,11 +2443,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2524,11 +2474,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2555,11 +2504,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2586,11 +2534,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2616,11 +2563,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2650,11 +2596,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2682,11 +2627,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2721,11 +2665,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2755,11 +2698,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2790,11 +2732,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2824,11 +2765,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2860,11 +2800,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -2905,10 +2844,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2943,11 +2881,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -2978,10 +2915,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3012,10 +2948,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3050,10 +2985,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3088,10 +3022,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3126,10 +3059,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3164,10 +3096,9 @@ exports.tests = [
         xs6: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3206,10 +3137,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3244,10 +3174,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3282,10 +3211,9 @@ exports.tests = [
         xs6: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3322,10 +3250,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3360,10 +3287,9 @@ exports.tests = [
         xs6: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3400,10 +3326,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3438,10 +3363,9 @@ exports.tests = [
         xs6: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3475,11 +3399,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3509,10 +3432,10 @@ exports.tests = [
         xs6: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        hermes0_12_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -3542,11 +3465,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3579,10 +3501,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -3613,10 +3534,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3661,10 +3581,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3704,10 +3623,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3740,11 +3658,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3779,11 +3696,10 @@ exports.tests = [
         ejs: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -3830,10 +3746,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3870,10 +3785,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3911,10 +3825,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3951,10 +3864,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -3993,10 +3905,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -4027,11 +3938,10 @@ exports.tests = [
         ejs: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -4072,10 +3982,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -4116,10 +4025,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -4158,10 +4066,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -4194,11 +4101,11 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        reactnative0_70_3: true,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     },
     {
@@ -4229,10 +4136,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -4262,10 +4168,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -4295,10 +4200,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -4330,10 +4234,9 @@ exports.tests = [
         xs6: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -4377,11 +4280,10 @@ exports.tests = [
         opera10_50: false,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
-        hermes0_7_0: false
+        hermes0_7_0: false,
+        reactnative0_70_3: false
       }
     },
     {
@@ -4410,11 +4312,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript1_0: true,
         jerryscript2_2_0: true,
-        hermes0_7_0: false
+        hermes0_7_0: false,
+        reactnative0_70_3: false
       }
     },
     {
@@ -4444,11 +4345,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_1_0: true,
-        hermes0_7_0: false
+        hermes0_7_0: false,
+        reactnative0_70_3: false
       }
     }
   ],
@@ -4486,11 +4386,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -4518,11 +4417,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -4550,11 +4448,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -4580,11 +4477,11 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -4609,11 +4506,11 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -4655,10 +4552,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -4693,10 +4589,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -4728,10 +4623,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -4762,10 +4656,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -4791,18 +4684,17 @@ exports.tests = [
         firefox2: false,
         firefox27: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome38: true,
         node0_12: true,
         xs6: true,
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -4829,18 +4721,17 @@ exports.tests = [
         firefox36: true,
         opera10_50: false,
         safari9: true,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome38: true,
         node0_12: true,
         xs6: true,
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -4874,11 +4765,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -4908,11 +4798,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -4944,11 +4833,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -4984,7 +4872,7 @@ exports.tests = [
         firefox2: false,
         firefox27: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome39: true,
         node0_12: "flagged",
         node4: true,
@@ -4996,11 +4884,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -5027,7 +4914,7 @@ exports.tests = [
         firefox2: false,
         firefox27: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome39: true,
         node0_12: "flagged",
         node4: true,
@@ -5039,11 +4926,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -5072,7 +4958,7 @@ exports.tests = [
         firefox2: false,
         firefox27: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome39: true,
         node0_12: "flagged",
         node4: true,
@@ -5084,11 +4970,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -5118,11 +5003,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5148,7 +5032,7 @@ exports.tests = [
         firefox2: false,
         firefox27: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome39: true,
         node0_12: "flagged",
         node4: true,
@@ -5159,11 +5043,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5187,7 +5070,7 @@ exports.tests = [
         firefox2: false,
         firefox27: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome39: true,
         node0_12: "flagged",
         node4: true,
@@ -5198,11 +5081,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5240,11 +5122,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5269,7 +5150,7 @@ exports.tests = [
         firefox2: false,
         firefox27: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome39: true,
         node0_12: "flagged",
         node4: true,
@@ -5280,11 +5161,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -5312,7 +5192,7 @@ exports.tests = [
         firefox2: false,
         firefox27: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome39: true,
         node0_12: "flagged",
         node4: true,
@@ -5324,11 +5204,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -5365,11 +5244,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5393,7 +5271,7 @@ exports.tests = [
         firefox2: false,
         firefox27: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome39: true,
         node0_12: "flagged",
         node4: true,
@@ -5405,11 +5283,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -5447,11 +5324,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -5489,11 +5365,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -5531,11 +5406,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -5572,11 +5446,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -5605,7 +5478,7 @@ exports.tests = [
         firefox2: false,
         firefox27: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome39: true,
         node0_12: "flagged",
         node4: true,
@@ -5616,11 +5489,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -5649,7 +5521,7 @@ exports.tests = [
         firefox2: false,
         firefox36: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome39: true,
         node0_12: "flagged",
         node4: true,
@@ -5660,11 +5532,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5704,11 +5575,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5747,11 +5617,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -5794,11 +5663,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5838,11 +5706,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5882,11 +5749,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5926,11 +5792,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -5970,11 +5835,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -6013,11 +5877,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -6057,11 +5920,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -6095,11 +5957,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -6143,11 +6004,10 @@ exports.tests = [
         duktape1_0: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -6181,11 +6041,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -6219,11 +6078,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -6259,11 +6117,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -6297,11 +6154,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -6341,11 +6197,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -6377,11 +6232,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -6408,11 +6262,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -6439,11 +6292,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -6482,11 +6334,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -6514,11 +6365,11 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        hermes0_12_0: true,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -6562,12 +6413,12 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        reactnative0_70_3: true,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     },
     {
@@ -6598,12 +6449,12 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        reactnative0_70_3: false,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     },
     {
@@ -6638,12 +6489,12 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        reactnative0_70_3: true,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     },
     {
@@ -6686,12 +6537,12 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7_13: false
+        reactnative0_70_3: true,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     },
     {
@@ -6733,12 +6584,12 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        reactnative0_70_3: true,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     }
   ],
@@ -6778,11 +6629,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -6815,11 +6665,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -6844,11 +6693,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -6874,11 +6722,10 @@ exports.tests = [
         safari12: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -6903,11 +6750,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -6931,11 +6777,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -6978,10 +6823,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7015,10 +6859,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7054,10 +6897,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7091,10 +6933,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7128,10 +6969,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7165,10 +7005,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7202,10 +7041,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7239,10 +7077,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7277,10 +7114,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7314,10 +7150,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7351,10 +7186,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7388,10 +7222,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7425,10 +7258,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7462,10 +7294,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7499,10 +7330,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7536,10 +7366,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7573,10 +7402,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -7602,11 +7430,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -7657,10 +7484,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -7699,11 +7525,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -7753,11 +7578,10 @@ exports.tests = [
         duktape2_1: true,
         duktape2_5: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -7780,10 +7604,9 @@ exports.tests = [
       jxa: true,
       duktape2_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7805,11 +7628,10 @@ exports.tests = [
       jxa: true,
       duktape2_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
-        rhino1_7_13: false
+      reactnative0_70_3: true,
+      rhino1_7_13: false
     }},
     {
       name: '.prototype.subarray',
@@ -7838,10 +7660,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: true
     }},
     {
@@ -7863,10 +7684,9 @@ exports.tests = [
       jxa: true,
       duktape2_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7888,12 +7708,11 @@ exports.tests = [
       jxa: true,
       duktape2_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: false,
       jerryscript2_1_0: true,
       hermes0_7_0: true,
-        rhino1_7_13: false
+      reactnative0_70_3: true,
+      rhino1_7_13: false
     }},
     {
       name: '.prototype.lastIndexOf',
@@ -7914,11 +7733,10 @@ exports.tests = [
       jxa: true,
       duktape2_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: false,
       jerryscript2_1_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7939,11 +7757,10 @@ exports.tests = [
       jxa: true,
       duktape2_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: false,
       jerryscript2_1_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7965,10 +7782,9 @@ exports.tests = [
       jxa: true,
       duktape2_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -7989,10 +7805,9 @@ exports.tests = [
       jxa: true,
       duktape2_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -8014,10 +7829,9 @@ exports.tests = [
       jxa: true,
       duktape2_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -8038,10 +7852,9 @@ exports.tests = [
       jxa: true,
       duktape2_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -8063,10 +7876,9 @@ exports.tests = [
       jxa: true,
       duktape2_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -8088,10 +7900,9 @@ exports.tests = [
       jxa: true,
       duktape2_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -8113,10 +7924,9 @@ exports.tests = [
       jxa: true,
       duktape2_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -8138,10 +7948,9 @@ exports.tests = [
       jxa: true,
       duktape2_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -8162,10 +7971,9 @@ exports.tests = [
       jxa: true,
       duktape2_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -8187,11 +7995,10 @@ exports.tests = [
       jxa: true,
       duktape2_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: false,
       jerryscript2_1_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -8213,10 +8020,9 @@ exports.tests = [
       jxa: true,
       duktape2_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -8238,10 +8044,9 @@ exports.tests = [
       jxa: true,
       duktape2_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -8263,10 +8068,9 @@ exports.tests = [
       jxa: true,
       duktape2_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -8288,10 +8092,9 @@ exports.tests = [
       jxa: true,
       duktape2_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -8313,10 +8116,9 @@ exports.tests = [
       jxa: true,
       duktape2_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -8337,10 +8139,9 @@ exports.tests = [
       jxa: true,
       duktape2_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: false
     }},
     {
@@ -8364,10 +8165,9 @@ exports.tests = [
       nashorn9: true,
       nashorn10: true,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
+      reactnative0_70_3: true,
       rhino1_7_13: true
     }},
     {
@@ -8389,11 +8189,10 @@ exports.tests = [
       jxa: true,
       duktape2_0: false,
       graalvm19: true,
-      graalvm20: true,
-      graalvm20_1: true,
       jerryscript2_0: false,
       jerryscript2_2_0: true,
       hermes0_7_0: false,
+      reactnative0_70_3: false,
       rhino1_7_13: false
     }}
     ].map(function(m) {
@@ -8444,7 +8243,7 @@ exports.tests = [
         firefox2: false,
         firefox13: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome38: true,
         safari7_1: true,
         node0_12: true,
@@ -8454,10 +8253,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8492,10 +8290,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8528,10 +8325,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8554,7 +8350,7 @@ exports.tests = [
         firefox17: false,
         firefox37: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome38: true,
         safari7_1: true,
         node0_12: true,
@@ -8564,10 +8360,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8604,11 +8399,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8638,11 +8432,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -8674,10 +8467,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8712,11 +8504,11 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8742,7 +8534,7 @@ exports.tests = [
         firefox2: false,
         firefox19: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome38: true,
         safari7_1: true,
         node0_12: true,
@@ -8752,10 +8544,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8776,7 +8567,7 @@ exports.tests = [
         firefox2: false,
         firefox13: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome38: true,
         safari7_1: true,
         node0_12: true,
@@ -8786,10 +8577,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8810,7 +8600,7 @@ exports.tests = [
         firefox2: false,
         firefox19: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome38: true,
         safari7_1: true,
         node0_12: true,
@@ -8820,10 +8610,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8854,10 +8643,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8889,10 +8677,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8924,10 +8711,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8959,10 +8745,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -8993,10 +8778,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9023,7 +8807,7 @@ exports.tests = [
         firefox2: false,
         firefox13: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome38: true,
         safari7_1: true,
         node0_12: true,
@@ -9033,10 +8817,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9074,10 +8857,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -9103,11 +8885,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -9142,7 +8923,7 @@ exports.tests = [
         firefox2: false,
         firefox13: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome38: true,
         safari7_1: true,
         node0_12: true,
@@ -9152,10 +8933,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9189,10 +8969,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9225,10 +9004,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9249,7 +9027,7 @@ exports.tests = [
         firefox2: false,
         firefox37: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome38: true,
         safari7_1: true,
         node0_12: true,
@@ -9259,10 +9037,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9299,11 +9076,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9336,11 +9112,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -9371,10 +9146,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9410,11 +9184,11 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9442,7 +9216,7 @@ exports.tests = [
         firefox2: false,
         firefox19: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome38: true,
         safari7_1: true,
         node0_12: true,
@@ -9452,10 +9226,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9476,7 +9249,7 @@ exports.tests = [
         firefox2: false,
         firefox13: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome38: true,
         safari7_1: true,
         node0_12: true,
@@ -9486,10 +9259,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9510,7 +9282,7 @@ exports.tests = [
         firefox2: false,
         firefox19: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome38: true,
         safari7_1: true,
         node0_12: true,
@@ -9520,10 +9292,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9554,10 +9325,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9588,10 +9358,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9623,10 +9392,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9658,10 +9426,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9693,10 +9460,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9723,7 +9489,7 @@ exports.tests = [
         firefox2: false,
         firefox13: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome38: true,
         safari7_1: true,
         node0_12: true,
@@ -9733,10 +9499,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9774,10 +9539,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -9803,11 +9567,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -9840,7 +9603,7 @@ exports.tests = [
         firefox2: false,
         firefox6: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome36: true,
         safari7_1: true,
         node0_12: true,
@@ -9850,11 +9613,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9887,11 +9649,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9923,11 +9684,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9949,7 +9709,7 @@ exports.tests = [
         firefox17: true,
         firefox37: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome36: true,
         safari7_1: true,
         node0_12: true,
@@ -9959,11 +9719,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -9999,11 +9758,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -10025,7 +9783,7 @@ exports.tests = [
         firefox2: false,
         firefox6: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome36: true,
         safari7_1: true,
         node0_12: true,
@@ -10035,11 +9793,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -10069,11 +9826,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10105,11 +9861,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -10129,7 +9884,7 @@ exports.tests = [
         firefox2: false,
         firefox6: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome36: true,
         safari7_1: true,
         node0_12: true,
@@ -10139,11 +9894,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -10181,11 +9935,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -10214,11 +9967,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -10243,7 +9995,7 @@ exports.tests = [
         firefox2: false,
         firefox40: true,
         opera10_50: false,
-        chrome21dev: chrome.experimental,
+        chrome21: chrome.experimental,
         chrome36: true,
         safari7_1: true,
         node0_12: true,
@@ -10253,11 +10005,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -10302,11 +10053,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -10337,11 +10087,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -10374,11 +10123,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -10409,11 +10157,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -10449,11 +10196,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -10483,11 +10229,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10518,11 +10263,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -10552,11 +10296,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -10591,11 +10334,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -10624,11 +10366,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -10664,11 +10405,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -10709,11 +10449,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10736,11 +10475,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10769,11 +10507,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10806,11 +10543,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10859,11 +10595,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10894,11 +10629,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10928,11 +10662,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -10981,11 +10714,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11015,11 +10747,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11048,11 +10779,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11098,11 +10828,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11132,11 +10861,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11173,11 +10901,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -11218,11 +10945,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11293,11 +11019,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11332,11 +11057,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11386,11 +11110,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11420,11 +11143,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11459,11 +11181,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -11498,11 +11219,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11539,11 +11259,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -11575,11 +11294,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11622,11 +11340,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11659,11 +11376,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11698,11 +11414,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -11741,11 +11456,10 @@ exports.tests = [
         duktape1_0: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11798,11 +11512,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -11835,11 +11548,10 @@ exports.tests = [
         duktape2_0: false,
         duktape2_2: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11874,11 +11586,10 @@ exports.tests = [
         duktape2_0: false,
         duktape2_2: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11909,11 +11620,10 @@ exports.tests = [
         duktape2_0: false,
         duktape2_2: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -11958,11 +11668,10 @@ exports.tests = [
         duktape2_0: false,
         duktape2_2: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -11992,11 +11701,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12019,11 +11727,10 @@ exports.tests = [
         duktape2_0: false,
         duktape2_5: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12048,11 +11755,10 @@ exports.tests = [
         duktape2_0: false,
         duktape2_5: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -12087,11 +11793,11 @@ exports.tests = [
         duktape2_0: false,
         duktape2_3: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12116,11 +11822,11 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12147,11 +11853,10 @@ exports.tests = [
         duktape2_0: false,
         duktape2_3: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12179,11 +11884,10 @@ exports.tests = [
         edge14: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -12208,11 +11912,10 @@ exports.tests = [
         duktape2_0: false,
         duktape2_2: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12238,11 +11941,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12278,11 +11980,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12315,11 +12016,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12343,11 +12043,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12371,11 +12070,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12399,11 +12097,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12428,11 +12125,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12458,11 +12154,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12489,11 +12184,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12502,7 +12196,7 @@ exports.tests = [
       exec: function() {/*
         // RegExp.prototype.flags -> Get -> [[Get]]
         var expected = [];
-        // Sorted alphabetically by shortname – "gumsuy".
+        // Sorted alphabetically by shortname – "gimsuy".
         if ('global' in RegExp.prototype) expected.push('global');
         if ('ignoreCase' in RegExp.prototype) expected.push('ignoreCase');
         if ('multiline' in RegExp.prototype) expected.push('multiline');
@@ -12531,11 +12225,11 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        graalvm22_2: graalvm.es6flag,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12559,11 +12253,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -12584,15 +12277,14 @@ exports.tests = [
         edge14: edge.experimental,
         chrome50: true,
         xs6: null,
-        echojs: null,
+        ejs: null,
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12618,11 +12310,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12648,11 +12339,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12679,14 +12369,13 @@ exports.tests = [
         node8: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_4_0: true,
         safari12: true,
         safaritp: true,
         webkit: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -12713,11 +12402,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -12742,11 +12430,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12779,11 +12466,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -12820,11 +12506,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12849,11 +12534,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12877,11 +12561,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12906,11 +12589,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12925,6 +12607,7 @@ exports.tests = [
         return get + '' === "length,constructor,1,2,3,length,constructor,2,1";
       */},
       res: {
+        closure: true,
         ejs: true,
         ie11: false,
         edge13: true,
@@ -12937,11 +12620,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -12966,11 +12648,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -12995,11 +12676,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13024,11 +12704,11 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13054,11 +12734,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13085,11 +12764,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13115,11 +12793,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13146,11 +12823,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13176,11 +12852,10 @@ exports.tests = [
         duktape2_0: false,
         duktape2_3: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -13214,11 +12889,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13243,11 +12917,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13272,11 +12945,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13300,11 +12972,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13328,11 +12999,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13356,11 +13026,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13384,11 +13053,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13412,11 +13080,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13442,11 +13109,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13472,11 +13138,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13502,11 +13167,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -13539,11 +13203,11 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        hermes0_12_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -13567,11 +13231,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -13604,11 +13267,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13635,11 +13297,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13665,11 +13326,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13695,11 +13355,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13725,11 +13384,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13755,11 +13413,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -13794,11 +13451,11 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        hermes0_12_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -13823,11 +13480,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13853,11 +13509,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -13882,11 +13537,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -13920,11 +13574,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -13949,11 +13602,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -13978,11 +13630,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -14020,11 +13671,10 @@ exports.tests = [
         duktape1_0: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14053,11 +13703,10 @@ exports.tests = [
         duktape1_0: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14084,11 +13733,10 @@ exports.tests = [
         duktape1_0: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14116,11 +13764,10 @@ exports.tests = [
         duktape1_0: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14149,11 +13796,10 @@ exports.tests = [
         chrome49: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14181,11 +13827,10 @@ exports.tests = [
         chrome49: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14211,11 +13856,10 @@ exports.tests = [
         chrome49: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14243,11 +13887,10 @@ exports.tests = [
         chrome49: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14274,11 +13917,10 @@ exports.tests = [
         chrome49: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14306,11 +13948,10 @@ exports.tests = [
         chrome49: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14341,11 +13982,10 @@ exports.tests = [
         duktape1_0: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14381,11 +14021,10 @@ exports.tests = [
         duktape1_0: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14411,11 +14050,10 @@ exports.tests = [
         chrome49: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14443,11 +14081,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14473,11 +14110,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14504,11 +14140,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14533,11 +14168,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14564,11 +14198,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -14592,11 +14225,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14638,11 +14270,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -14675,7 +14306,7 @@ exports.tests = [
     firefox2: false,
     firefox46: true,
     opera10_50: false,
-    chrome21dev: chrome.experimental,
+    chrome21: chrome.experimental,
     chrome41: true,
     node0_12: "flagged",
     node4: true,
@@ -14686,11 +14317,10 @@ exports.tests = [
     nashorn9: true,
     nashorn10: true,
     graalvm19: true,
-    graalvm20: true,
-    graalvm20_1: true,
     jerryscript2_0: false,
     jerryscript2_3_0: true,
     hermes0_7_0: false,
+    reactnative0_70_3: true,
     rhino1_7_13: false
   }
 },
@@ -14728,11 +14358,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -14763,11 +14392,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -14798,11 +14426,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -14831,11 +14458,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14864,11 +14490,10 @@ exports.tests = [
         node6_5: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14898,11 +14523,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14932,11 +14556,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -14966,11 +14589,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -15000,11 +14622,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15040,11 +14661,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15078,11 +14698,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15114,11 +14733,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15163,11 +14781,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15197,11 +14814,10 @@ exports.tests = [
         node6_5: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -15233,11 +14849,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15270,11 +14885,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15303,11 +14917,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -15338,11 +14951,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15376,11 +14988,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.catchDestructuring,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -15413,11 +15024,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -15449,11 +15059,11 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -15489,11 +15099,11 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        hermes0_12_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -15534,11 +15144,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15570,11 +15179,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15606,11 +15214,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15640,11 +15247,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -15674,11 +15280,10 @@ exports.tests = [
         node6_5: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -15709,11 +15314,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -15744,11 +15348,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -15778,11 +15381,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -15812,11 +15414,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15847,11 +15448,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15883,11 +15483,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -15924,12 +15523,12 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        reactnative0_70_3: true,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     },
     {
@@ -15965,12 +15564,12 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        reactnative0_70_3: true,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     },
     {
@@ -16004,12 +15603,12 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        reactnative0_70_3: true,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     },
     {
@@ -16038,12 +15637,12 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        reactnative0_70_3: true,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     },
     {
@@ -16077,11 +15676,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -16115,12 +15713,12 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        reactnative0_70_3: true,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     },
     {
@@ -16165,12 +15763,12 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        reactnative0_70_3: true,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     },
     {
@@ -16199,11 +15797,10 @@ exports.tests = [
         node6_5: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -16240,12 +15837,12 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        reactnative0_70_3: true,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     },
     {
@@ -16278,11 +15875,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -16311,11 +15907,10 @@ exports.tests = [
         node6_5: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -16347,11 +15942,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -16384,11 +15978,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -16429,11 +16022,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -16465,11 +16057,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -16501,11 +16092,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -16535,11 +16125,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -16570,11 +16159,10 @@ exports.tests = [
         node6_5: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -16605,11 +16193,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -16640,11 +16227,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -16673,11 +16259,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -16709,11 +16294,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -16750,11 +16334,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -16788,11 +16371,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -16825,11 +16407,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -16868,11 +16449,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -16903,11 +16483,10 @@ exports.tests = [
         node6_5: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -16940,11 +16519,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -16977,11 +16555,10 @@ exports.tests = [
         node6_5: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -17009,11 +16586,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },{
@@ -17042,11 +16618,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -17079,11 +16654,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17114,11 +16688,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -17150,11 +16723,10 @@ exports.tests = [
         node6_5: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17184,11 +16756,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17215,11 +16786,10 @@ exports.tests = [
         node6_5: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17234,9 +16804,9 @@ exports.tests = [
         babel6corejs2: true,
         closure: true,
         typescript1corejs2: true,
-        traceur: true,
+        tr: true,
         ie11: false,
-        edge11: false,
+        edge12: false,
         edge15: true,
         chrome47: chrome.experimental,
         chrome49: true,
@@ -17250,11 +16820,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17269,7 +16838,7 @@ exports.tests = [
         babel6corejs2: true,
         closure: true,
         typescript1corejs2: true,
-        traceur: true,
+        tr: true,
         ie11: false,
         edge15: false,
         edge18: true,
@@ -17285,11 +16854,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17324,12 +16892,12 @@ exports.tests = [
         node6: true,
         node6_5: true,
         jxa: true,
+        duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: true
+        reactnative0_70_3: true,
+        rhino1_7_13: false
       }
     }
   ],
@@ -17386,11 +16954,11 @@ exports.tests = [
         xs6: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17422,11 +16990,12 @@ exports.tests = [
         xs6: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: false,
-        rhino1_7_13: false
+        hermes0_12_0: true,
+        reactnative0_70_3: true,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     },
     {
@@ -17458,11 +17027,11 @@ exports.tests = [
         xs6: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: false,
-        rhino1_7_13: false
+        reactnative0_70_3: false,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     },
     {
@@ -17502,11 +17071,11 @@ exports.tests = [
         xs6: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17545,11 +17114,10 @@ exports.tests = [
         xs6: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -17591,11 +17159,11 @@ exports.tests = [
         xs6: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -17634,11 +17202,10 @@ exports.tests = [
         xs6: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -17663,12 +17230,12 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7_13: false
+        reactnative0_70_3: false,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     }
   ],
@@ -17705,10 +17272,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -17741,11 +17307,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -17783,10 +17348,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -17816,10 +17380,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -17856,10 +17419,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -17886,11 +17448,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -17920,11 +17481,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -17951,11 +17511,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -17982,11 +17541,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18013,11 +17571,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18044,11 +17601,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18075,11 +17631,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18106,11 +17661,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18138,11 +17692,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -18165,6 +17718,7 @@ exports.tests = [
         ie11: true,
         firefox2: true,
         chrome5: true,
+        deno1_0: false,
         safari3_1: true,
         opera10_50: true,
         opera12: true,
@@ -18181,11 +17735,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -18199,6 +17752,7 @@ exports.tests = [
         ie11: true,
         firefox2: true,
         chrome5: true,
+        deno1_0: false,
         safari3_1: true,
         opera10_50: true,
         opera12: true,
@@ -18213,11 +17767,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -18244,10 +17797,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript1_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -18261,6 +17813,7 @@ exports.tests = [
         ie11: true,
         firefox2: true,
         chrome30: true,
+        deno1_0: false,
         safari3_1: true,
         opera10_50: false,
         opera12_10: true,
@@ -18274,11 +17827,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -18299,6 +17851,7 @@ exports.tests = [
         firefox2: false,
         firefox17: true,
         chrome30: true,
+        deno1_0: false,
         safari6: true,
         opera10_50: false,
         opera12_10: true,
@@ -18310,11 +17863,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -18330,6 +17882,7 @@ exports.tests = [
         firefox10: false,
         firefox39: true,
         chrome30: true,
+        deno1_0: false,
         safari6: true,
         opera10_50: false,
         opera12_10: true,
@@ -18341,11 +17894,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -18388,11 +17940,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18425,11 +17976,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18455,11 +18005,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18484,11 +18033,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -18514,11 +18062,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -18547,11 +18094,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -18577,11 +18123,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -18609,11 +18154,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -18640,10 +18184,9 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -18674,11 +18217,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -18709,11 +18251,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -18738,11 +18279,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -18771,11 +18311,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -18804,11 +18343,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -18835,11 +18373,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -18866,11 +18403,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -18895,11 +18431,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -18936,12 +18471,12 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        reactnative0_70_3: true,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     },
     {
@@ -18971,11 +18506,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -19014,11 +18548,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -19044,10 +18577,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -19079,10 +18611,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -19115,10 +18646,9 @@ exports.tests = [
         duktape2_0: false,
         duktape2_1: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -19154,10 +18684,9 @@ exports.tests = [
         duktape2_0: false,
         duktape2_1: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -19190,10 +18719,9 @@ exports.tests = [
         duktape2_0: false,
         duktape2_1: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -19229,10 +18757,9 @@ exports.tests = [
         duktape2_0: false,
         duktape2_1: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -19270,10 +18797,9 @@ exports.tests = [
         duktape2_0: false,
         duktape2_1: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -19303,10 +18829,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -19343,10 +18868,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -19390,10 +18914,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
-        hermes0_7_0: false
+        hermes0_7_0: false,
+        reactnative0_70_3: false
       }
     },
     {
@@ -19427,10 +18950,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
-        hermes0_7_0: false
+        hermes0_7_0: false,
+        reactnative0_70_3: false
       }
     },
     {
@@ -19462,11 +18984,11 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         hermes0_7_0: false,
-        rhino1_7_13: false
+        reactnative0_70_3: false,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     }
   ],
@@ -19501,11 +19023,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -19530,11 +19051,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_4_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -19558,11 +19078,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_4_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -19583,11 +19102,10 @@ exports.tests = [
         node4: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_4_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -19628,11 +19146,10 @@ exports.tests = [
         duktape2_0: false,
         duktape2_2: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -19666,11 +19183,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -19713,10 +19229,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -19745,10 +19260,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -19787,10 +19301,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -19829,10 +19342,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -19865,10 +19377,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -19906,10 +19417,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -19932,10 +19442,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -19969,10 +19478,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -20006,10 +19514,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -20047,11 +19554,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -20097,11 +19603,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -20130,10 +19635,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -20180,16 +19684,15 @@ exports.tests = [
         duktape2_0: false,
         duktape2_3: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
     {
-      name: 'Symbol.isConcatSpreadable',
+      name: 'Symbol.isConcatSpreadable, non-spreadable array',
       mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/isConcatSpreadable',
       exec: function() {/*
         var a = [], b = [];
@@ -20215,12 +19718,49 @@ exports.tests = [
         duktape2_0: false,
         duktape2_3: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
+      }
+    },
+    {
+      name: 'Symbol.isConcatSpreadable, spreadable object with poisoned getter',
+      mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/isConcatSpreadable',
+      exec: function() {/*
+        if (typeof Symbol !== 'function' || !Symbol.isConcatSpreadable) {
+          return null;
+        }
+        var spreadableHasPoisonedIndex = { length: Math.pow(2, 53) - 1 };
+        spreadableHasPoisonedIndex[Symbol.isConcatSpreadable] = true;
+        Object.defineProperty(spreadableHasPoisonedIndex, 0, {
+          get: function () { throw new SyntaxError(); }
+        });
+        try {
+          [].concat(spreadableHasPoisonedIndex);
+          return false;
+        } catch (e) {
+          return !!e && e.name === 'SyntaxError';
+        }
+      */},
+      res: {
+        chrome48: false,
+        chrome100: false,
+        chrome101: false,
+        safari5_1: false,
+        safari9: false,
+        safari12_1: false,
+        safari13: false,
+        safari14: true,
+        safari15: true,
+        firefox48: true,
+        firefox60: true,
+        firefox70: true,
+        firefox99: true,
+        graalvm21_3_3: true,
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -20251,10 +19791,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -20283,11 +19822,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -20313,10 +19851,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: true
       }
     },
@@ -20348,11 +19885,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -20384,11 +19920,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -20420,11 +19955,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -20456,11 +19990,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -20492,11 +20025,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -20530,11 +20062,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -20563,12 +20094,12 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7_13: false
+        reactnative0_70_3: false,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     },
     {
@@ -20596,11 +20127,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -20629,11 +20159,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -20662,11 +20191,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -20695,11 +20223,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -20727,11 +20254,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -20760,11 +20286,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -20793,11 +20318,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -20826,11 +20350,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -20864,11 +20387,10 @@ exports.tests = [
         duktape2_0: false,
         duktape2_3: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -20898,10 +20420,9 @@ exports.tests = [
         duktape2_0: false,
         duktape2_3: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -20949,10 +20470,9 @@ exports.tests = [
         duktape2_3: true,
         duktape2_5: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -20999,11 +20519,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -21031,10 +20550,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -21067,11 +20585,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -21107,11 +20624,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_1_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -21136,11 +20652,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -21165,11 +20680,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -21194,11 +20708,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -21223,11 +20736,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -21253,11 +20765,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -21296,10 +20807,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript1_0: true,
-        hermes0_7_0: false
+        hermes0_7_0: false,
+        reactnative0_70_3: false
       }
     },
     {
@@ -21327,10 +20837,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
-        hermes0_7_0: false
+        hermes0_7_0: false,
+        reactnative0_70_3: false
       }
     }
   ]
@@ -21365,10 +20874,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -21394,10 +20902,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -21422,10 +20929,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript1_0: true,
-        hermes0_7_0: false
+        hermes0_7_0: false,
+        reactnative0_70_3: false
       }
     },
     {
@@ -21452,10 +20958,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -21481,10 +20986,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -21512,11 +21016,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -21541,11 +21044,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -21573,10 +21075,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     }
   ],
@@ -21612,11 +21113,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -21645,11 +21145,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -21678,11 +21177,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -21710,11 +21208,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -21743,11 +21240,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -21777,11 +21273,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -21811,11 +21306,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -21844,11 +21338,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -21879,11 +21372,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -21915,11 +21407,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -21945,11 +21436,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -21985,11 +21475,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -22020,10 +21509,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -22054,10 +21542,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -22088,11 +21575,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -22124,10 +21610,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -22188,10 +21673,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -22223,11 +21707,85 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
+      }
+    },
+    {
+      name: 'Array.prototype.splice',
+      mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice',
+      exec: function () {/*
+        if ([0, 1, 2].splice(0).length !== 3) {
+          // IE <= 8 and other pre-ES6 engines fail this check
+          return false;
+        }
+
+        var a = [1, 2];
+        var result = a.splice();
+        if (a.length !== 2 || result.length !== 0) {
+          // Safari 5.0 has this bug
+          return false;
+        }
+
+        var obj = {};
+        Array.prototype.splice.call(obj, 0, 0, 1);
+        if (obj.length !== 1) {
+          return false;
+        }
+
+        var spliceWorksWithLargeSparseArrays = (function () {
+          // Per https://github.com/es-shims/es5-shim/issues/295
+          // Safari 7/8 breaks with sparse arrays of size 1e5 or greater
+          var arr = new Array(1e5);
+          // note: the index MUST be 8 or larger or the test will false pass
+          arr[8] = 'x';
+          arr.splice(1, 1);
+          for (var i = 0; i < arr.length; i += 1) {
+            if (arr[i] === 'x') {
+              return i === 7;
+            }
+          }
+          return false;
+        }());
+        var spliceWorksWithSmallSparseArrays = (function () {
+          // Per https://github.com/es-shims/es5-shim/issues/295
+          // Opera 12.15 breaks on this, no idea why.
+          var n = 256;
+          var arr = [];
+          arr[n] = 'a';
+          arr.splice(n + 1, 0, 'b');
+          return arr[n] === 'a';
+        }());
+
+        return spliceWorksWithLargeSparseArrays && spliceWorksWithSmallSparseArrays;
+      */},
+      res: {
+        ie8: false,
+        ie9: true,
+        ie11: true,
+        chrome15: false,
+        chrome16: true,
+        chrome18: true,
+        chrome20: true,
+        chrome40: true,
+        chrome50: true,
+        chrome101: true,
+        firefox3: null,
+        firefox13: true,
+        firefox15: true,
+        firefox20: true,
+        opera10_50: null,
+        opera12: false,
+        opera12_10: false,
+        safari4: false,
+        safari5: false,
+        safari5_1: true,
+        safari15: true,
+        graalvm21_3_3: true,
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -22265,10 +21823,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -22304,10 +21861,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -22340,11 +21896,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -22384,11 +21939,10 @@ exports.tests = [
         duktape2_0: false,
         duktape2_3: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_1_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -22419,11 +21973,10 @@ exports.tests = [
         duktape2_0: false,
         duktape2_3: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_1_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -22454,11 +22007,10 @@ exports.tests = [
         duktape2_0: false,
         duktape2_3: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_1_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -22490,11 +22042,10 @@ exports.tests = [
         duktape2_0: false,
         duktape2_3: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_1_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -22521,12 +22072,12 @@ exports.tests = [
         duktape2_0: false,
         duktape2_3: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        reactnative0_70_3: true,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     },
     {
@@ -22552,12 +22103,12 @@ exports.tests = [
         duktape2_0: false,
         duktape2_3: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        reactnative0_70_3: true,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     },
     {
@@ -22586,12 +22137,12 @@ exports.tests = [
         duktape2_0: false,
         duktape2_3: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        reactnative0_70_3: true,
+        rhino1_7_13: false,
+        rhino1_7_14: true,
       }
     },
     {
@@ -22621,11 +22172,10 @@ exports.tests = [
         duktape2_0: false,
         duktape2_3: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -22656,11 +22206,10 @@ exports.tests = [
         duktape2_0: false,
         duktape2_3: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -22694,11 +22243,10 @@ exports.tests = [
         duktape2_0: false,
         duktape2_2: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'imul': {
@@ -22713,7 +22261,7 @@ exports.tests = [
         firefox2: false,
         firefox23: true,
         opera10_50: false,
-        chrome21dev: {
+        chrome21: {
           val: true,
           note_id: 'chromu-imul',
           note_html: 'Available since Chrome 28'
@@ -22728,11 +22276,10 @@ exports.tests = [
         duktape2_0: false,
         duktape2_2: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'sign': {
@@ -22757,10 +22304,9 @@ exports.tests = [
         duktape2_0: false,
         duktape2_2: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'log10': {
@@ -22783,11 +22329,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'log2': {
@@ -22811,11 +22356,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'log1p': {
@@ -22839,11 +22383,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'expm1': {
@@ -22866,11 +22409,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'cosh': {
@@ -22894,11 +22436,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'sinh': {
@@ -22922,11 +22463,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'tanh': {
@@ -22950,11 +22490,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'acosh': {
@@ -22978,11 +22517,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'asinh': {
@@ -23005,11 +22543,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'atanh': {
@@ -23033,11 +22570,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'trunc': {
@@ -23061,10 +22597,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'fround': {
@@ -23092,11 +22627,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       },
       'cbrt': {
@@ -23120,11 +22654,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     };
@@ -23167,11 +22700,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     });
@@ -23204,11 +22736,10 @@ exports.tests = [
     duktape2_0: false,
     duktape2_3: true,
     graalvm19: true,
-    graalvm20: true,
-    graalvm20_1: true,
     jerryscript2_0: false,
     jerryscript2_2_0: true,
     hermes0_7_0: true,
+    reactnative0_70_3: true,
     rhino1_7_13: false
   }
 },
@@ -23245,10 +22776,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23278,10 +22808,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23310,10 +22839,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -23339,10 +22867,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23368,11 +22895,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -23398,11 +22924,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -23428,11 +22953,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -23459,11 +22983,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -23490,11 +23013,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
-        hermes0_7_0: hermes.class,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -23522,11 +23044,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23554,11 +23075,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -23595,10 +23115,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23628,10 +23147,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -23660,10 +23178,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23692,10 +23209,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -23730,10 +23246,9 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23760,10 +23275,9 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -23792,10 +23306,9 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23822,10 +23335,9 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23852,10 +23364,9 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23881,11 +23392,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -23940,11 +23450,10 @@ exports.tests = [
         ejs: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -23973,10 +23482,9 @@ exports.tests = [
         ejs: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -24015,11 +23523,10 @@ exports.tests = [
         xs6: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -24058,11 +23565,10 @@ exports.tests = [
         xs6: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -24099,10 +23605,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -24131,10 +23636,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -24165,10 +23669,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -24197,10 +23700,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -24232,10 +23734,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -24268,10 +23769,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -24331,7 +23831,7 @@ exports.tests = [
         safari4: true,
         android4_0: true,
         xs6: true,
-        phantom: true,
+        phantom1_9: true,
         ejs: false,
         konq4_14: null,
         rhino1_7_13: true,
@@ -24341,10 +23841,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -24384,10 +23883,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript1_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -24433,10 +23931,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -24482,10 +23979,9 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript1_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -24524,10 +24020,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript1_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -24572,11 +24067,10 @@ exports.tests = [
         chrome49: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -24618,11 +24112,10 @@ exports.tests = [
         duktape2_0: false,
         duktape2_2: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -24651,7 +24144,7 @@ exports.tests = [
         jsx: null,
         typescript1corejs2: null,
         es6shim: null,
-        konq414: null,
+        konq4_14: null,
         ie7: null,
         ie10: false,
         ie11: true,
@@ -24673,12 +24166,11 @@ exports.tests = [
         android1_5: null,
         ios4: null,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript1_0: true,
         jerryscript2_0: false,
         jerryscript2_4_0: true,
-        hermes0_7_0: false
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
       }
     },
     {
@@ -24695,7 +24187,7 @@ exports.tests = [
         jsx: null,
         typescript1corejs2: null,
         es6shim: null,
-        konq414: null,
+        konq4_14: null,
         ie7: null,
         ie10: false,
         edge12: null,
@@ -24717,11 +24209,10 @@ exports.tests = [
         android1_5: null,
         ios4: null,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_4_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -24742,7 +24233,7 @@ exports.tests = [
         jsx: true,
         typescript1corejs2: true,
         es6shim: null,
-        konq414: null,
+        konq4_14: null,
         ie7: null,
         ie10: true,
         firefox1: null,
@@ -24764,11 +24255,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
-        hermes0_7_0: false
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
       }
     }
   ],
@@ -24801,10 +24291,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -24834,10 +24323,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -24869,11 +24357,10 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -24900,11 +24387,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -24935,10 +24421,9 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript1_0: true,
-        hermes0_7_0: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -24961,11 +24446,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -24989,11 +24473,10 @@ exports.tests = [
         safari10: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -25027,11 +24510,11 @@ exports.tests = [
         safari10: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
+        hermes0_12_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -25061,11 +24544,10 @@ exports.tests = [
         jxa: true,
         duktape2_0: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -25100,10 +24582,9 @@ exports.tests = [
     duktape2_0: false,
     duktape2_1: true,
     graalvm19: true,
-    graalvm20: true,
-    graalvm20_1: true,
     jerryscript2_0: false,
-    hermes0_7_0: false
+    hermes0_7_0: false,
+    reactnative0_70_3: false
   }
 },
 ];

--- a/test/ecmascript/data-esintl.js
+++ b/test/ecmascript/data-esintl.js
@@ -29,8 +29,8 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -51,8 +51,8 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -80,8 +80,8 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -103,8 +103,8 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -126,8 +126,8 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -191,8 +191,8 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -200,6 +200,7 @@ exports.tests = [
       name: 'rejects invalid language tags',
       spec: 'https://github.com/tc39/ecma402/pull/289',
       exec: function(){/*
+        if (typeof Intl.Collator !== 'function') return false;
         try {
           // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js
           var invalidLanguageTags = [
@@ -223,9 +224,11 @@ exports.tests = [
         firefox76: true,
         chrome81: true,
         safari14: false,
+        duktape2_0: false,
         graalvm19: false,
-        graalvm20: false,
         graalvm20_1: true,
+        hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -253,8 +256,8 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -282,8 +285,8 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -311,8 +314,8 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -333,8 +336,8 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -356,8 +359,8 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -379,8 +382,8 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -444,18 +447,19 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
     {
-      name: 'accepts valid language tags',
+      name: 'rejects invalid language tags',
       spec: 'https://github.com/tc39/ecma402/pull/289',
       exec: function(){/*
+        if (typeof Intl.NumberFormat !== 'function') return false;
         try {
           // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js
-          var validLanguageTags = [
+          var invalidLanguageTags = [
             "i-klingon", // grandfathered tag
             "x-en-US-12345", // anything goes in private use tags
             "x-12345-12345-en-US",
@@ -476,9 +480,10 @@ exports.tests = [
         firefox76: true,
         chrome81: true,
         safari14: true,
+        duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -506,8 +511,8 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -529,8 +534,8 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -552,8 +557,8 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -617,8 +622,8 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -626,6 +631,7 @@ exports.tests = [
       name: 'rejects invalid language tags',
       spec: 'https://github.com/tc39/ecma402/pull/289',
       exec: function(){/*
+        if (typeof Intl.DateTimeFormat !== 'function') return false;
         try {
           // Taken from https://github.com/tc39/test262/blob/83b07ff15eadb141c3d6f4d236a8733b720041d2/test/intl402/6.2.2_a.js
           var invalidLanguageTags = [
@@ -648,9 +654,11 @@ exports.tests = [
         edge18: false,
         firefox76: true,
         chrome81: true,
+        duktape2_0: false,
         graalvm19: false,
-        graalvm20: false,
         graalvm20_1: true,
+        hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     },
@@ -679,8 +687,8 @@ exports.tests = [
         ios7: false,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     },
@@ -709,8 +717,8 @@ exports.tests = [
         node0_12: true,
         duktape2_0: false,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: false,
+        reactnative0_70_3: true,
         rhino1_7_13: false
       }
     }
@@ -742,8 +750,8 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -775,8 +783,8 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -808,8 +816,8 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -841,8 +849,8 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -874,8 +882,8 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -907,8 +915,8 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }
@@ -940,8 +948,8 @@ exports.tests = [
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true,
+        hermes0_7_0: true,
+        reactnative0_70_3: true,
         rhino1_7_13: true
       }
     }

--- a/test/ecmascript/data-esnext.js
+++ b/test/ecmascript/data-esnext.js
@@ -3,7 +3,7 @@ var common = require('./data-common');
 var babel = common.babel;
 var typescript = common.typescript;
 // var firefox = common.firefox;
-// var graalvm = common.graalvm;
+var graalvm = common.graalvm;
 
 exports.name = 'ES Next';
 exports.target_file = 'esnext/index.html';
@@ -35,8 +35,8 @@ exports.tests = [
     chrome77: false,
     duktape2_0: false,
     graalvm19: false,
-    graalvm20: false,
-    graalvm20_1: false,
+    hermes0_7_0: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false
   }
 },
@@ -69,22 +69,22 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm19: false,
-        graalvm20: false,
-        graalvm20_1: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
   ],
 },
 {
-  name: 'Realms',
+  name: 'ShadowRealm',
   category: STAGE3,
   significance: 'large',
-  spec: 'https://github.com/tc39/proposal-realms',
+  spec: 'https://github.com/tc39/proposal-shadowrealm',
   exec: function () {/*
-    return typeof Realm === "function"
-      && ["eval", "global", "intrinsics", "stdlib", "directEval", "indirectEval", "initGlobal", "nonEval"].every(function(key){
-        return key in Realm.prototype;
+    return typeof ShadowRealm === "function"
+      && ["evaluate", "importValue"].every(function(key){
+        return key in ShadowRealm.prototype;
       });
   */},
   res: {
@@ -95,8 +95,8 @@ exports.tests = [
     chrome77: false,
     duktape2_0: false,
     graalvm19: false,
-    graalvm20: false,
-    graalvm20_1: false,
+    hermes0_7_0: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false
   }
 },
@@ -126,8 +126,8 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm19: false,
-        graalvm20: false,
-        graalvm20_1: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -155,8 +155,8 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm19: false,
-        graalvm20: false,
-        graalvm20_1: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -179,8 +179,8 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm19: false,
-        graalvm20: false,
-        graalvm20_1: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -203,8 +203,8 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm19: false,
-        graalvm20: false,
-        graalvm20_1: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -234,8 +234,9 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm19: false,
-        graalvm20: false,
-        graalvm20_1: false,
+        graalvm21_3_3: graalvm.newSetMethodsFlag,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -258,8 +259,9 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm19: false,
-        graalvm20: false,
-        graalvm20_1: false,
+        graalvm21_3_3: graalvm.newSetMethodsFlag,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -281,8 +283,9 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm19: false,
-        graalvm20: false,
-        graalvm20_1: false,
+        graalvm21_3_3: graalvm.newSetMethodsFlag,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -304,8 +307,9 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm19: false,
-        graalvm20: false,
-        graalvm20_1: false,
+        graalvm21_3_3: graalvm.newSetMethodsFlag,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -324,8 +328,10 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm19: false,
-        graalvm20: false,
-        graalvm20_1: false,
+        graalvm20_1: graalvm.es2021flag,
+        graalvm21_3_3: graalvm.newSetMethodsFlag,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -344,8 +350,9 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm19: false,
-        graalvm20: false,
-        graalvm20_1: false,
+        graalvm21_3_3: graalvm.newSetMethodsFlag,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -364,8 +371,9 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm19: false,
-        graalvm20: false,
-        graalvm20_1: false,
+        graalvm21_3_3: graalvm.newSetMethodsFlag,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -392,6 +400,9 @@ exports.tests = [
         chrome70: false,
         safari12: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -410,6 +421,9 @@ exports.tests = [
         chrome70: false,
         safari12: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -440,15 +454,15 @@ exports.tests = [
         konq4_4: true,
         besen: false,
         rhino1_7_13: true,
-        phantom: true,
+        phantom1_9: true,
         android4_0: true,
         duktape2_0: false,
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     },
     {
@@ -471,15 +485,15 @@ exports.tests = [
         konq4_4: true,
         besen: false,
         rhino1_7_13: true,
-        phantom: true,
+        phantom1_9: true,
         android4_0: true,
         duktape2_0: false,
         nashorn1_8: true,
         nashorn9: true,
         nashorn10: true,
         graalvm19: true,
-        graalvm20: true,
-        graalvm20_1: true
+        hermes0_7_0: true,
+        reactnative0_70_3: true
       }
     }
   ]
@@ -508,6 +522,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -530,6 +547,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }
@@ -542,7 +562,7 @@ exports.tests = [
   spec: 'https://github.com/tc39/proposal-array-is-template-object',
   exec: function () {/*
     return !Array.isTemplateObject([])
-      && Array.isTemplateObject((it => it)`a{1}c`);
+      && Array.isTemplateObject((it => it)`a${1}c`);
   */},
   res: {
     babel6corejs2: false,
@@ -554,6 +574,9 @@ exports.tests = [
     firefox60: false,
     chrome77: false,
     duktape2_0: false,
+    graalvm21_3_3: false,
+    hermes0_7_0: false,
+    reactnative0_70_3: false,
     rhino1_7_13: false
   }
 },
@@ -578,6 +601,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -598,6 +624,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -619,6 +648,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -645,6 +677,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -663,6 +698,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -681,6 +719,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -699,6 +740,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -717,6 +761,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -735,6 +782,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -753,6 +803,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -773,6 +826,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -791,6 +847,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -809,6 +868,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -827,6 +889,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -845,6 +910,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -864,6 +932,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -882,6 +953,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -900,6 +974,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -920,6 +997,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -950,6 +1030,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -980,6 +1063,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1010,6 +1096,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1036,6 +1125,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1062,6 +1154,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1082,6 +1177,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1108,6 +1206,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1128,6 +1229,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1154,6 +1258,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1175,6 +1282,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1201,6 +1311,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1221,6 +1334,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1241,6 +1357,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1267,6 +1386,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1287,6 +1409,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     },
@@ -1305,92 +1430,9 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
-      }
-    }
-  ]
-},
-{
-  name: 'Hashbang Grammar',
-  category: STAGE3,
-  significance: 'tiny',
-  spec: 'https://github.com/tc39/proposal-hashbang/',
-  mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Hashbang_comments',
-  exec: function() {/*
-    try {
-      return !eval('#!/wash/your/hands');
-    } catch (e) {
-      return false
-    }
-  */},
-  res: {
-    chrome1: false,
-    chrome74: true,
-    firefox2: false,
-    firefox67: true,
-    ie11: false,
-    opera10_50: false,
-    edge18: false,
-    safari1: false,
-    safari13: false,
-    safari13_1: true,
-    duktape2_0: false,
-    graalvm19: false,
-    graalvm20: false,
-    graalvm20_1: true,
-    babel7corejs3: false,
-    typescript3_2corejs3: false,
-    closure: false,
-    rhino1_7_13: false
-  }
-},
-{
-  name: 'Array find from last',
-  category: STAGE3,
-  significance: 'small',
-  spec: 'https://github.com/tc39/proposal-array-find-from-last',
-  subtests: [
-    {
-      name: "Array.prototype.findLast",
-      exec: function () {/*
-        var arr = [{ x: 1 }, { x: 2 }, { x: 1 }, { x: 2 }];
-        return arr.findLast(function (o) { return o.x === 1; }) === arr[2];
-      */},
-      res: {
-        babel7corejs3: babel.corejs,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        chrome1: false,
-        chrome90: false,
-        edge18: false,
-        firefox2: false,
-        firefox89: false,
-        opera10_50: false,
-        safari12: false,
-        safaritp: true,
-        duktape2_0: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: "Array.prototype.findLastIndex",
-      exec: function () {/*
-        var arr = [{ x: 1 }, { x: 2 }, { x: 1 }, { x: 2 }];
-        return arr.findLastIndex(function (o) { return o.x === 1; }) === 2;
-      */},
-      res: {
-        babel7corejs3: babel.corejs,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        chrome1: false,
-        chrome90: false,
-        edge18: false,
-        firefox2: false,
-        firefox89: false,
-        opera10_50: false,
-        safari12: false,
-        safaritp: true,
-        duktape2_0: false,
+        graalvm21_3_3: false,
+        hermes0_7_0: false,
+        reactnative0_70_3: false,
         rhino1_7_13: false
       }
     }


### PR DESCRIPTION
## About this test suite

These tests came from [kangax compat table](https://github.com/kangax/compat-table) which tests for specific ES features.

In our case, we only need to test parsing and not actually execute the tests.

## Updating

You can run the following script from this directory to update this test suite.

```sh
curl -L -o data-common.json https://raw.githubusercontent.com/kangax/compat-table/gh-pages/data-common.json
curl -L -o data-es5.js https://raw.githubusercontent.com/kangax/compat-table/gh-pages/data-es5.js
curl -L -o data-es6.js https://raw.githubusercontent.com/kangax/compat-table/gh-pages/data-es6.js
curl -L -o data-es2016plus.js https://raw.githubusercontent.com/kangax/compat-table/gh-pages/data-es2016plus.js
curl -L -o data-esintl.js https://raw.githubusercontent.com/kangax/compat-table/gh-pages/data-esintl.js
curl -L -o data-esnext.js https://raw.githubusercontent.com/kangax/compat-table/gh-pages/data-esnext.js
```