### PR TITLE
feat(resolve): export `resolve()` function

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,25 @@ The following FS functions can be hooked by passing them as options:
 * `readlink(path): Promise<string>`
 * `resolve(id: string, parent: string): Promise<string | string[]>`
 
+##### Advanced Resolving
+
+When providing a custom resolve hook you are responsible for returning one or more absolute paths to resolved files based on the `id` input. However it may be the case that you only want to augment or override the resolve behavior in certain cases. You can use `nft`'s underlying resolver by importing it. The builtin `resolve` function expects additional arguments that need to be forwarded from the hook
+
+* `resolve(id: string, parent: string, job: Job, isCjs: boolean): Promise<string | string[]>`
+
+Here is an example showing one id being resolved to a bespoke path while all other paths being resolved by the builting resolver
+```js
+const { nodeFileTrace, resolve } = require('@vercel/nft');
+const files = ['./src/main.js', './src/second.js'];
+const { fileList } = await nodeFileTrace(files, { resolve: async (id, parent, job, isCjs) => {
+  if (id === './src/main.js') {
+    return '/path/to/some/resolved/main/file.js'
+  } else {
+    return resolve(id, parent, job, isCjs)
+  }
+}});
+```
+
 #### TypeScript
 
 The internal resolution supports resolving `.ts` files in traces by default.

--- a/readme.md
+++ b/readme.md
@@ -115,7 +115,7 @@ When providing a custom resolve hook you are responsible for returning one or mo
 
 * `resolve(id: string, parent: string, job: Job, isCjs: boolean): Promise<string | string[]>`
 
-Here is an example showing one id being resolved to a bespoke path while all other paths being resolved by the builting resolver
+Here is an example showing one id being resolved to a bespoke path while all other paths being resolved by the built-in resolver
 ```js
 const { nodeFileTrace, resolve } = require('@vercel/nft');
 const files = ['./src/main.js', './src/second.js'];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export * from './types';
 export { nodeFileTrace } from './node-file-trace';
 import resolveDependency from './resolve-dependency';
-export { resolveDependency };
+export { resolveDependency as resolve };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
 export * from './types';
 export { nodeFileTrace } from './node-file-trace';
+import resolveDependency from './resolve-dependency';
+export { resolveDependency };


### PR DESCRIPTION
nft allows you to override the resolve step with a hook however it does not expose its internal resolveDependency implementation. This means if you want to take over resolving in certain cases you must do so in every case. To make conditional or augmented resolving possible this change reexports the resolveDependency function from the index. This way you can use it in custom resolve hook implementations