### PR TITLE
chore(ci): fix redis connection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     services:
       if: ${{ matrix.os == 'ubuntu-latest' }}
       redis:
-        image: redis:6.0.20 # https://hub.docker.com/_/redis
+        image: ${{ (matrix.os == 'ubuntu-latest') && 'redis:6.0.20' || '' }}
         ports:
           - 6379:6379
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         node: [14, 16, 18]
     runs-on: ${{ matrix.os }}
+    services:
+      redis:
+        image: redis:6.0.20 # https://hub.docker.com/_/redis
+        ports:
+          - 6379:6379
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node }}
@@ -36,7 +41,7 @@ jobs:
       run: yarn build
     - name: Run Tests
       env:
-        BULL_REDIS_CONNECTION: ${{ secrets.BULL_REDIS_CONNECTION }}
+        BULL_REDIS_CONNECTION: "http://127.0.0.1:6379"
       run: yarn test-verbose
     - name: Maybe Release
       if: matrix.os == 'ubuntu-latest' && matrix.node == 18 && github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
         node: [14, 16, 18]
     runs-on: ${{ matrix.os }}
     services:
-      if: ${{ matrix.os == 'ubuntu-latest' }}
       redis:
         image: ${{ (matrix.os == 'ubuntu-latest') && 'redis:6.0.20' || '' }}
         ports:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       run: yarn build
     - name: Run Tests
       env:
-        BULL_REDIS_CONNECTION: "redis://127.0.0.1:6379/0"
+        BULL_REDIS_CONNECTION: ${{ (matrix.os == 'ubuntu-latest') && 'redis://127.0.0.1:6379/0' || '' }}
       run: yarn test-verbose
     - name: Maybe Release
       if: matrix.os == 'ubuntu-latest' && matrix.node == 18 && github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         node: [14, 16, 18]
     runs-on: ${{ matrix.os }}
     services:
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       redis:
         image: redis:6.0.20 # https://hub.docker.com/_/redis
         ports:
@@ -41,7 +42,7 @@ jobs:
       run: yarn build
     - name: Run Tests
       env:
-        BULL_REDIS_CONNECTION: "http://127.0.0.1:6379"
+        BULL_REDIS_CONNECTION: "redis://127.0.0.1:6379/0"
       run: yarn test-verbose
     - name: Maybe Release
       if: matrix.os == 'ubuntu-latest' && matrix.node == 18 && github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     services:
       redis:
+        # See workaround https://github.com/actions/runner/issues/822#issuecomment-1524826092
         image: ${{ (matrix.os == 'ubuntu-latest') && 'redis:6.0.20' || '' }}
         ports:
           - 6379:6379


### PR DESCRIPTION
Previously the `BULL_REDIS_CONNECTION` env var was a remote redis instance.

That token instance must have changed hostnames or expired because it started failing with [`getaddrinfo ENOTFOUND`](https://github.com/vercel/nft/actions/runs/5350038924/jobs/9702103910#step:7:8979).

This PR removes the need for a remote instance and instead uses github actions [service container](https://docs.github.com/en/actions/using-containerized-services/creating-redis-service-containers) to starts and stop redis.