### PR TITLE
fix: use `builtinModules` from `module`

### DIFF
--- a/src/resolve-dependency.ts
+++ b/src/resolve-dependency.ts
@@ -1,4 +1,5 @@
 import { isAbsolute, resolve, sep } from 'path';
+import { builtinModules } from 'module';
 import { Job } from './node-file-trace';
 
 // node resolver
@@ -68,7 +69,7 @@ export class NotFoundError extends Error {
   }
 }
 
-const nodeBuiltins = new Set<string>([...require("repl")._builtinLibs, "constants", "module", "timers", "console", "_stream_writable", "_stream_readable", "_stream_duplex", "process", "sys"]);
+const nodeBuiltins = new Set<string>(builtinModules);
 
 function getPkgName (name: string) {
   const segments = name.split('/');


### PR DESCRIPTION
This feels like the better choice rather than using a private property on `repl`.

supported as of [v6.13.0](https://nodejs.org/api/module.html#modulebuiltinmodules)