### PR TITLE
fix: Revert "fix: resolve cjs deps as cjs instead of esm (#362)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@types/graceful-fs": "^4.1.5",
     "@types/micromatch": "^4.0.1",
     "@types/node": "^14.14.37",
-    "@vercel/edge-config": "^0.4.0",
     "analytics-node": "^3.4.0-beta.1",
     "apollo-server-express": "^2.14.2",
     "argon2": "^0.31.1",

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -328,7 +328,7 @@ export class Job {
         else
           await this.emitFile(asset, 'asset', path);
       }),
-      ...[...deps].map(async dep => this.maybeEmitDep(dep, path, !isESM || this.mixedModules)),
+      ...[...deps].map(async dep => this.maybeEmitDep(dep, path, !isESM)),
       ...[...imports].map(async dep => this.maybeEmitDep(dep, path, false)),
     ]);
   }

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -13,7 +13,6 @@ const integrationDir = `${__dirname}${path.sep}integration`;
 for (const integrationTest of readdirSync(integrationDir)) {
   it(`should correctly trace and correctly execute ${integrationTest}`, async () => {
     console.log('Tracing and executing ' + integrationTest);
-    const mixedModules = integrationTest === 'vercel-edge-config-esm.mjs';
     const nftCache = {}
     const fails = integrationTest.endsWith('failure.js');
     const { fileList, reasons, warnings } = await nodeFileTrace([`${integrationDir}/${integrationTest}`], {
@@ -22,8 +21,7 @@ for (const integrationTest of readdirSync(integrationDir)) {
       base: path.resolve(__dirname, '..'),
       processCwd: integrationDir,
       // ignore other integration tests
-      ignore: ['test/integration/**'],
-      mixedModules
+      ignore: ['test/integration/**']
     });
     // warnings.forEach(warning => console.warn(warning));
     const randomTmpId = Math.random().toString().slice(2)
@@ -64,8 +62,7 @@ for (const integrationTest of readdirSync(integrationDir)) {
         base: path.resolve(__dirname, '..'),
         processCwd: integrationDir,
         // ignore other integration tests
-        ignore: ['test/integration/**'],
-        mixedModules
+        ignore: ['test/integration/**']
       });
       expect([...cachedResult.fileList].sort()).toEqual([...fileList].sort())
     }

--- a/test/integration/vercel-edge-config-esm.mjs
+++ b/test/integration/vercel-edge-config-esm.mjs
@@ -1,9 +1,0 @@
-import { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
-
-// this will load the CJS export and should not be treated as ESM
-const ec = require('@vercel/edge-config');
-
-// this will cause the file to be treated as ESM
-export default function foo() {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2420,18 +2420,6 @@
   dependencies:
     "@types/node" "*"
 
-"@vercel/edge-config-fs@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@vercel/edge-config-fs/-/edge-config-fs-0.1.0.tgz#cda8327f611418c1d1cbb28c6bed02d782be928b"
-  integrity sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg==
-
-"@vercel/edge-config@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@vercel/edge-config/-/edge-config-0.4.0.tgz#e3649125778d450e6702dfa3ed7ad3e93e16d2c4"
-  integrity sha512-v8AKiW/Tp9S79xapH3gXmOPXkkzJhUNnpyL6OX8xbHJvP7y5x0Oo/v/FUsGHpgay1x8a5vpddTH0Upw04RQcRA==
-  dependencies:
-    "@vercel/edge-config-fs" "0.1.0"
-
 "@webcomponents/template@^1.4.0":
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/@webcomponents/template/-/template-1.4.4.tgz#2ca5a68b65b6e9cd9b17b25a951514f254c00742"


### PR DESCRIPTION
This reverts commit 1eba4d507bcfc0d34ae51d98ed1b285dc4537923.

The fix in the original PR did solve the problem of tracing a dependency being loaded from an ESM file via `require()`, but also caused a regression where a simple `.mjs` file with ESM imports was failing. I have a test (https://github.com/vercel/nft/pull/364) for that.