### PR TITLE
chore: fix mac node 16 test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node }}
+    - name: Install node-gyp deps
+      run: python3 -m pip install distutils
     - name: Prepare Install (if applicable)
       run: node prepare-install.js
     - name: Install Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,10 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node }}
-    - name: Install node-gyp deps
-      run: python3 -m pip install distutils
+    - uses: actions/setup-python@v4
+      with:
+        # we lock to 3.11 for a distutils requirement for node-gyp
+        python-version: '3.11' 
     - name: Prepare Install (if applicable)
       run: node prepare-install.js
     - name: Install Dependencies


### PR DESCRIPTION
Locks our python version for our macOS node 16 test job

x-ref: https://github.com/vercel/nft/actions/runs/7067408413/job/19240984319