### PR TITLE
fix: rollback engines to `>=16`

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "when": "^3.7.8"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=16"
   },
   "packageManager": "npm@10.2.5",
   "publishConfig": {


### PR DESCRIPTION
This is a partial revert of PR https://github.com/vercel/nft/pull/374

It was dropping support for node@16 in CI but it didn't modify `target` in tsconfig.json, so 16 is still supported.

Furthermore, 16 is going to be [supported by Vercel a little longer](https://vercel.com/changelog/node-js-14-and-16-are-being-deprecated).

This fixes the warning when installing Vercel CLI using node@16

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@vercel/nft@0.26.1',
npm WARN EBADENGINE   required: { node: '>=18' },
npm WARN EBADENGINE   current: { node: 'v16.18.1', npm: '8.19.2' }
npm WARN EBADENGINE }
```