### PR TITLE
chore: remove canvas test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Run Tests
       env:
         BULL_REDIS_CONNECTION: ${{ (matrix.os == 'ubuntu-latest') && 'redis://127.0.0.1:6379/0' || '' }}
-      run: npm run test-verbose
+      run: npm run ${{ (matrix.os == 'ubuntu-latest') && 'test-verbose' || 'test' }}
     - name: Maybe Release
       if: matrix.os == 'ubuntu-latest' && matrix.node == 18 && github.event_name == 'push' && github.ref == 'refs/heads/main'
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-14, windows-latest]
         node: [18, 20]
     runs-on: ${{ matrix.os }}
     services:

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,9 +3,9 @@ module.exports = {
   coverageReporters: ["html", "lcov"],
   coverageThreshold: {
     global: {
-      branches: 80.5,
-      functions: 95.2,
-      lines: 85.87,
+      branches: 87.36,
+      functions: 96.25,
+      lines: 92.4,
       statements: -249
     }
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,9 +3,9 @@ module.exports = {
   coverageReporters: ["html", "lcov"],
   coverageThreshold: {
     global: {
-      branches: 87.36,
+      branches: 87.29,
       functions: 96.25,
-      lines: 92.4,
+      lines: 92.33,
       statements: -249
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,6 @@
         "bull": "^3.10.0",
         "bullmq": "^4.10.0",
         "camaro": "^6.1.0",
-        "canvas": "^2.11.2",
         "chromeless": "^1.5.2",
         "consolidate": "^0.15.1",
         "copy": "^0.3.2",
@@ -7389,6 +7388,8 @@
       "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
       "dev": true,
       "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
         "nan": "^2.17.0",
@@ -28801,6 +28802,8 @@
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
       "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "decompress-response": "^4.2.0",
         "once": "^1.3.1",
@@ -28812,6 +28815,8 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
       "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "mimic-response": "^2.0.0"
       },
@@ -28824,6 +28829,8 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
       "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -21978,7 +21978,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -21994,19 +21994,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22021,7 +22021,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -22039,7 +22039,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "bull": "^3.10.0",
     "bullmq": "^4.10.0",
     "camaro": "^6.1.0",
-    "canvas": "^2.11.2",
     "chromeless": "^1.5.2",
     "consolidate": "^0.15.1",
     "copy": "^0.3.2",

--- a/test/integration/canvas.js
+++ b/test/integration/canvas.js
@@ -1,6 +1,0 @@
-const canvas = require('canvas');
-module.exports = () => {
-  const { createCanvas } = canvas;
-  const c = createCanvas(200, 200);
-  const ctx = c.getContext('2d');
-};


### PR DESCRIPTION
This fixes an issue when a contributor (or [GH Actions](https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/)) runs `npm install` using Apple Silicon which would fail since there is no precompiled arm64 binary to download for `canvas`. The error looks like this:

```
npm ERR! node-pre-gyp http GET https://github.com/Automattic/node-canvas/releases/download/v2.11.2/canvas-v2.11.2-node-v108-darwin-unknown-arm64.tar.gz
npm ERR! node-pre-gyp ERR! install response status 404 Not Found on https://github.com/Automattic/node-canvas/releases/download/v2.11.2/canvas-v2.11.2-node-v108-darwin-unknown-arm64.tar.gz 
npm ERR! node-pre-gyp WARN Pre-built binaries not installable for canvas@2.11.2 and node@18.19.0 (node-v108 ABI, unknown) (falling back to source compile with node-gyp) 
```

Since we don't have a [special case](https://github.com/vercel/nft/blob/main/src/utils/special-cases.ts) for `canvas` and it never worked with Vercel deployments, we can remove the test.

It also doesn't decrease code coverage (in fact, I bumped code coverage thresholds just to be sure).

### Related
- https://github.com/Automattic/node-canvas/issues/1733
- https://github.com/vercel/vercel/issues/3460