### PR TITLE
fix(analyze): node-gyp-build not including zeromq prebuilds

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,9 +3,9 @@ module.exports = {
   coverageReporters: ["html", "lcov"],
   coverageThreshold: {
     global: {
-      branches: 87.27,
+      branches: 87.29,
       functions: 96.25,
-      lines: 92.28,
+      lines: 92.33,
       statements: -249
     }
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,9 +3,9 @@ module.exports = {
   coverageReporters: ["html", "lcov"],
   coverageThreshold: {
     global: {
-      branches: 87.29,
+      branches: 87.27,
       functions: 96.25,
-      lines: 92.33,
+      lines: 92.28,
       statements: -249
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
+        "@aminya/node-gyp-build": "^4.5.0-aminya.5",
         "@mapbox/node-pre-gyp": "^1.0.5",
         "@rollup/pluginutils": "^4.0.0",
         "acorn": "^8.6.0",
@@ -126,6 +127,16 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@aminya/node-gyp-build": {
+      "version": "4.5.0-aminya.5",
+      "resolved": "https://registry.npmjs.org/@aminya/node-gyp-build/-/node-gyp-build-4.5.0-aminya.5.tgz",
+      "integrity": "sha512-TO7GldxDfSeSRNZVmhlm0liS2GX2o2Q/qTlcD3iD4ltTM6dir568LTRZ+ZDsDbLfMAkfhrbU+VuzNYImwYfczg==",
+      "bin": {
+        "aminya-node-gyp-build": "bin.js",
+        "aminya-node-gyp-build-optional": "optional.js",
+        "aminya-node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -21978,7 +21989,7 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -21994,19 +22005,19 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -22021,7 +22032,7 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -22039,7 +22050,7 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "@aminya/node-gyp-build": "4.5.0-aminya.5",
         "@mapbox/node-pre-gyp": "^1.0.5",
         "@rollup/pluginutils": "^4.0.0",
         "acorn": "^8.6.0",
@@ -134,6 +133,7 @@
       "version": "4.5.0-aminya.5",
       "resolved": "https://registry.npmjs.org/@aminya/node-gyp-build/-/node-gyp-build-4.5.0-aminya.5.tgz",
       "integrity": "sha512-TO7GldxDfSeSRNZVmhlm0liS2GX2o2Q/qTlcD3iD4ltTM6dir568LTRZ+ZDsDbLfMAkfhrbU+VuzNYImwYfczg==",
+      "dev": true,
       "bin": {
         "aminya-node-gyp-build": "bin.js",
         "aminya-node-gyp-build-optional": "optional.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "@aminya/node-gyp-build": "^4.5.0-aminya.5",
+        "@aminya/node-gyp-build": "4.5.0-aminya.5",
         "@mapbox/node-pre-gyp": "^1.0.5",
         "@rollup/pluginutils": "^4.0.0",
         "acorn": "^8.6.0",
@@ -123,7 +123,8 @@
         "vm2": "^3.9.18",
         "vue": "^2.6.10",
         "vue-server-renderer": "^2.6.10",
-        "when": "^3.7.8"
+        "when": "^3.7.8",
+        "zeromq": "^6.0.0-beta.19"
       },
       "engines": {
         "node": ">=16"
@@ -8665,6 +8666,24 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-fetch": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
@@ -13685,6 +13704,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/intl": {
@@ -27342,6 +27370,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/redis": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
@@ -28741,6 +28781,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/shiki": {
       "version": "0.14.7",
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
@@ -28761,6 +28818,31 @@
       "dev": true,
       "dependencies": {
         "nanoid": "^2.1.0"
+      }
+    },
+    "node_modules/shx": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.3",
+        "shelljs": "^0.8.5"
+      },
+      "bin": {
+        "shx": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/shx/node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -33588,6 +33670,23 @@
       "dependencies": {
         "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"
+      }
+    },
+    "node_modules/zeromq": {
+      "version": "6.0.0-beta.19",
+      "resolved": "https://registry.npmjs.org/zeromq/-/zeromq-6.0.0-beta.19.tgz",
+      "integrity": "sha512-2eU6H7Z4r9LmTkseGdIfEqp0k3rJr5EpXQw2oC0bUqy3wpoj1M83IU/c3qHPXp0z8IklNMoVmVm130d3g2Xf3g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@aminya/node-gyp-build": "4.5.0-aminya.5",
+        "cross-env": "^7.0.3",
+        "node-addon-api": "^7.0.0",
+        "shelljs": "^0.8.5",
+        "shx": "^0.3.4"
+      },
+      "engines": {
+        "node": ">= 10.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "vue": "^2.6.10",
     "vue-server-renderer": "^2.6.10",
     "when": "^3.7.8",
-    "zeromq": "6.0.0-beta.19"
+    "zeromq": "^6.0.0-beta.19"
   },
   "engines": {
     "node": ">=16"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "tsc",
     "prepublishOnly": "tsc && rm out/utils/*.d.ts && rm out/tsconfig.tsbuildinfo",
     "test": "jest --verbose",
+    "test-watch": "jest --watch",
     "test-verbose": "tsc --sourceMap && jest --verbose --coverage --globals \"{\\\"coverage\\\":true}\""
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "out"
   ],
   "dependencies": {
-    "@aminya/node-gyp-build": "4.5.0-aminya.5",
     "@mapbox/node-pre-gyp": "^1.0.5",
     "@rollup/pluginutils": "^4.0.0",
     "acorn": "^8.6.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "out"
   ],
   "dependencies": {
+    "@aminya/node-gyp-build": "4.5.0-aminya.5",
     "@mapbox/node-pre-gyp": "^1.0.5",
     "@rollup/pluginutils": "^4.0.0",
     "acorn": "^8.6.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
     "vm2": "^3.9.18",
     "vue": "^2.6.10",
     "vue-server-renderer": "^2.6.10",
-    "when": "^3.7.8"
+    "when": "^3.7.8",
+    "zeromq": "6.0.0-beta.19"
   },
   "engines": {
     "node": ">=16"

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -13,10 +13,6 @@ import handleSpecialCases from './utils/special-cases';
 import { Node } from './utils/types';
 import resolve from './resolve-dependency.js';
 //@ts-ignore
-import nodeGypBuild from 'node-gyp-build';
-//@ts-ignore
-import aminyaNodeGypBuild from '@aminya/node-gyp-build';
-//@ts-ignore
 import mapboxPregyp from '@mapbox/node-pre-gyp';
 import { Job } from './node-file-trace';
 import { fileURLToPath, pathToFileURL, URL } from 'url';
@@ -641,27 +637,19 @@ export default async function analyze(id: string, code: string, job: Job): Promi
                   ? path.join(dir, node.arguments[0].arguments[1].value)
                   : dir;
 
-                const nodeGypBuildPkgName = node.callee.arguments[0].value;
+                const pkgName = node.callee.arguments[0].value;
                 let resolved: string | undefined;
                 try {
                   // use installed version of node-gyp-build since resolving
                   // binaries can differ among versions
-                  const nodeGypBuildPath = resolveFrom(pathJoinedDir, nodeGypBuildPkgName)
+                  const nodeGypBuildPath = resolveFrom(pathJoinedDir, pkgName)
                   resolved = require(nodeGypBuildPath).path(pathJoinedDir)
                 } catch (e) {
                   try {
-                    switch (nodeGypBuildPkgName) {
-                      case 'node-gyp-build':
-                        resolved = nodeGypBuild.path(pathJoinedDir);
-                        break;
-                      case '@aminya/node-gyp-build':
-                        // zeromq uses this fork of node-gyp-build
-                        resolved = aminyaNodeGypBuild.path(pathJoinedDir);
-                        break;
-                      default:
-                        // should never happen since NODE_GYP_BUILD is assigned to these packages only
-                        job.warnings.add(new Error(`Unknown node-gyp-build package name: "${nodeGypBuildPkgName}"`));
-                    }
+                    const nodeGypBuild = '@aminya/node-gyp-build'
+                      ? require('@aminya/node-gyp-build')
+                      : require('node-gyp-build');
+                    resolved = nodeGypBuild.path(pathJoinedDir);
                   } catch (e) {}
                 }
                 if (resolved) {

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -628,8 +628,8 @@ export default async function analyze(id: string, code: string, job: Job): Promi
               // handle case: require("node-gyp-build")(path.join(__dirname, ".."))
               const calledWithPathJoinDirname =
                 node.arguments.length === 1 &&
-                node.arguments[0].callee.object.name === "path" &&
-                node.arguments[0].callee.property.name === "join" &&
+                node.arguments[0].callee?.object?.name === "path" &&
+                node.arguments[0].callee?.property?.name === "join" &&
                 node.arguments[0].arguments.length === 2 &&
                 node.arguments[0].arguments[0].type === 'Identifier' &&
                 node.arguments[0].arguments[0].name === '__dirname' &&

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -13,6 +13,8 @@ import handleSpecialCases from './utils/special-cases';
 import { Node } from './utils/types';
 import resolve from './resolve-dependency.js';
 //@ts-ignore
+import nodeGypBuild from 'node-gyp-build';
+//@ts-ignore
 import mapboxPregyp from '@mapbox/node-pre-gyp';
 import { Job } from './node-file-trace';
 import { fileURLToPath, pathToFileURL, URL } from 'url';
@@ -637,18 +639,16 @@ export default async function analyze(id: string, code: string, job: Job): Promi
                   ? path.join(dir, node.arguments[0].arguments[1].value)
                   : dir;
 
-                const pkgName = node.callee.arguments[0].value;
                 let resolved: string | undefined;
                 try {
+                  // the pkg could be 'node-gyp-build' or '@aminya/node-gyp-build'
+                  const pkgName = node.callee.arguments[0].value;
                   // use installed version of node-gyp-build since resolving
                   // binaries can differ among versions
                   const nodeGypBuildPath = resolveFrom(pathJoinedDir, pkgName)
                   resolved = require(nodeGypBuildPath).path(pathJoinedDir)
                 } catch (e) {
                   try {
-                    const nodeGypBuild = '@aminya/node-gyp-build'
-                      ? require('@aminya/node-gyp-build')
-                      : require('node-gyp-build');
                     resolved = nodeGypBuild.path(pathJoinedDir);
                   } catch (e) {}
                 }

--- a/test/integration/zeromq.js
+++ b/test/integration/zeromq.js
@@ -1,0 +1,2 @@
+const zmq = require("zeromq");
+const sock = new zmq.Push;

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -203,25 +203,14 @@ for (const { testName, isRoot } of unitTests) {
       }
       let sortedFileList = [...fileList].sort()
 
-      if (testName === 'microtime-node-gyp') {
+      if (testName === 'microtime-node-gyp' || testName === 'zeromq-node-gyp') {
         let foundMatchingBinary = false
+        const isBinaryFnMap = {
+          'microtime-node-gyp': file => file.endsWith('node-napi.node') || file.endsWith('node.napi.node'),
+          'zeromq-node-gyp': file => file.endsWith('node.napi.glibc.node') || file.endsWith('node.napi.musl.node'),
+        }
         sortedFileList = sortedFileList.filter(file => {
-          if (file.endsWith('node-napi.node') || file.endsWith('node.napi.node')) {
-            // remove from fileList for expected checking
-            // as it will differ per platform
-            foundMatchingBinary = true
-            fileList.delete(file)
-            return false
-          }
-          return true
-        })
-        expect(foundMatchingBinary).toBe(true)
-      }
-
-      if (testName === 'zeromq-node-gyp') {
-        let foundMatchingBinary = false
-        sortedFileList = sortedFileList.filter(file => {
-          if (file.startsWith('node.napi.')) {
+          if (isBinaryFnMap[testName](file)) {
             // remove from fileList for expected checking
             // as it will differ per platform
             foundMatchingBinary = true

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -205,12 +205,8 @@ for (const { testName, isRoot } of unitTests) {
 
       if (testName === 'microtime-node-gyp' || testName === 'zeromq-node-gyp') {
         let foundMatchingBinary = false
-        const isBinaryFnMap = {
-          'microtime-node-gyp': file => file.endsWith('node-napi.node') || file.endsWith('node.napi.node'),
-          'zeromq-node-gyp': file => file.endsWith('node.napi.glibc.node') || file.endsWith('node.napi.musl.node'),
-        }
         sortedFileList = sortedFileList.filter(file => {
-          if (isBinaryFnMap[testName](file)) {
+          if (file.includes('prebuilds') && file.endsWith('.node')) {
             // remove from fileList for expected checking
             // as it will differ per platform
             foundMatchingBinary = true

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -218,6 +218,21 @@ for (const { testName, isRoot } of unitTests) {
         expect(foundMatchingBinary).toBe(true)
       }
 
+      if (testName === 'zeromq-node-gyp') {
+        let foundMatchingBinary = false
+        sortedFileList = sortedFileList.filter(file => {
+          if (file.startsWith('node.napi.')) {
+            // remove from fileList for expected checking
+            // as it will differ per platform
+            foundMatchingBinary = true
+            fileList.delete(file)
+            return false
+          }
+          return true
+        })
+        expect(foundMatchingBinary).toBe(true)
+      }
+
       let expected;
       try {
         expected = JSON.parse(fs.readFileSync(join(unitPath, outputFileName)).toString());

--- a/test/unit/zeromq-node-gyp/input.js
+++ b/test/unit/zeromq-node-gyp/input.js
@@ -1,0 +1,1 @@
+require('zeromq');

--- a/test/unit/zeromq-node-gyp/input.js
+++ b/test/unit/zeromq-node-gyp/input.js
@@ -1,1 +1,2 @@
-require('zeromq');
+const zeromq = require('zeromq');
+const sock = new zmq.Push;

--- a/test/unit/zeromq-node-gyp/output.js
+++ b/test/unit/zeromq-node-gyp/output.js
@@ -1,9 +1,11 @@
 [
+  "node_modules/@aminya/node-gyp-build/index.js",
+  "node_modules/@aminya/node-gyp-build/package.json",
   "node_modules/zeromq/lib/draft.js",
   "node_modules/zeromq/lib/index.js",
   "node_modules/zeromq/lib/native.js",
   "node_modules/zeromq/lib/util.js",
   "node_modules/zeromq/package.json",
-  "node_modules/zeromq/prebuilds/darwin-x64/node.napi.glibc.node",
-  "test/unit/zeromq-node-gyp/input.js",
-];
+  "package.json",
+  "test/unit/zeromq-node-gyp/input.js"
+]

--- a/test/unit/zeromq-node-gyp/output.js
+++ b/test/unit/zeromq-node-gyp/output.js
@@ -1,0 +1,9 @@
+[
+  "node_modules/zeromq/lib/draft.js",
+  "node_modules/zeromq/lib/index.js",
+  "node_modules/zeromq/lib/native.js",
+  "node_modules/zeromq/lib/util.js",
+  "node_modules/zeromq/package.json",
+  "node_modules/zeromq/prebuilds/darwin-x64/node.napi.glibc.node",
+  "test/unit/zeromq-node-gyp/input.js",
+];


### PR DESCRIPTION
- Fixes #391 

Three things I want to point out:

1. In zeromq the way node-gyp-build is called is by passing `path.join(__dirname, "..")` instead of `__dirname` to the `require("node-gyp-build")(...)` call.
2. In zeromq they use `@aminya/node-gyp-build` instead of `node-gyp-build`, particular-li version `4.5.0-aminya.5`.
3. The zeromq version that's recommended for new project is the `6` which is beta according to @aminya https://github.com/zeromq/zeromq.js.

After those changes it resolves OK.

```
❯ node ./node_modules/@vercel/nft/out/cli.js print ./node_modules/zeromq/lib/index.js
FILELIST:
node_modules/@aminya/node-gyp-build/index.js
node_modules/@aminya/node-gyp-build/package.json
node_modules/zeromq/lib/draft.js
node_modules/zeromq/lib/index.js
node_modules/zeromq/lib/native.js
node_modules/zeromq/lib/util.js
node_modules/zeromq/package.json
node_modules/zeromq/prebuilds/darwin-x64/node.napi.glibc.node <---- It worked!

```