### PR TITLE
feat: add `analysis.transformAST` hook

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -172,6 +172,19 @@ const { fileList } = await nodeFileTrace(files, {
     computeFileReferences: true,
     // evaluate known bindings to assist with glob and file reference analysis
     evaluatePureExpressions: true,
+    // optional hook into the analysis step to inspect or modify the generated AST
+    transformAST: async (path, ast) => {
+      await walk(ast, {
+        async enter(node) {
+          if (
+            node.type === 'ImportDeclaration' &&
+            node.source.value === 'foo'
+          ) {
+            this.remove();
+          }
+        },
+      });
+    },
   },
 });
 ```

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -338,6 +338,10 @@ export default async function analyze(
     }
   }
 
+  if (job.analysis.transformAST) {
+    await job.analysis.transformAST(id, ast);
+  }
+
   const importMetaUrl = pathToFileURL(id).href;
 
   const knownBindings: Record<

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -9,6 +9,7 @@ import analyze, { AnalyzeResult } from './analyze';
 import resolveDependency, { NotFoundError } from './resolve-dependency';
 import { isMatch } from 'micromatch';
 import { sharedLibEmit } from './utils/sharedlib-emit';
+import { Node } from './utils/types';
 import { join } from 'path';
 import { CachedFileSystem } from './fs';
 
@@ -61,6 +62,7 @@ export class Job {
     emitGlobs?: boolean;
     computeFileReferences?: boolean;
     evaluatePureExpressions?: boolean;
+    transformAST?: (path: string, node: Node) => Promise<void>;
   };
   private analysisCache: Map<string, AnalyzeResult>;
   public fileList: Set<string>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { Job } from './node-file-trace';
+import { Node } from './utils/types';
 
 export interface Stats {
   isFile(): boolean;
@@ -41,6 +42,7 @@ export interface NodeFileTraceOptions {
         emitGlobs?: boolean;
         computeFileReferences?: boolean;
         evaluatePureExpressions?: boolean;
+        transformAST?: (path: string, node: Node) => Promise<void>;
       };
   cache?: any;
   paths?: Record<string, string>;

--- a/test/unit/imports-transform-ast/input.js
+++ b/test/unit/imports-transform-ast/input.js
@@ -1,0 +1,2 @@
+import { x } from '#x';
+console.log(x);

--- a/test/unit/imports-transform-ast/output.js
+++ b/test/unit/imports-transform-ast/output.js
@@ -1,0 +1,4 @@
+[
+  "test/unit/imports-transform-ast/input.js",
+  "test/unit/imports-transform-ast/package.json"
+]

--- a/test/unit/imports-transform-ast/package.json
+++ b/test/unit/imports-transform-ast/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "x",
+  "type": "module"
+}


### PR DESCRIPTION
**TL;DR:** Adds a `transformAST` callback that lets consumers inspect and/or modify the analysis step.

When processing a code bundle, it's often times useful to statically analyse the code to extract additional information, and potentially modify it to conditionally remove dependencies or perform different types of optimisations.

I know that this is not part of the scope of NFT, and there are a plethora of tools out there that let you do this on top of the dependency tracing step, but lexing and parsing are expensive operations that one would avoiding duplicating if possible.

Since NFT is already doing those operations when analysis is enabled, this PR adds an optional `transformAST` hook that lets consumers read and optionally modify the AST for each file before dependencies are traced. This callback receives the path and the AST root node.

This callback is supplied via the `analysis.transformAST` property, and it's an optional hook in line with the existing `readFile`, `stat`, `readlink`, and `resolve` callbacks.

I tried to do this in the least invasive way, with a minimal change in the implementation. If you have any thoughts on how this could be done different, I'll be happy to make those changes. If you'd rather not add this at all, that's also totally understandable, but I think this could be a useful feature so I wanted to propose it.

Thanks!