### PR TITLE
chore(readme): Add parentheses to the end of functions in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ By default the `process.cwd()` is used:
 
 ```js
 const { fileList } = await nodeFileTrace(files, {
-  base: process.cwd()
+  base: process.cwd(),
 });
 ```
 
@@ -51,7 +51,7 @@ Setting the `processCwd` option allows this analysis to be guided to the right p
 
 ```js
 const { fileList } = await nodeFileTrace(files, {
-  processCwd: path.resolve(__dirname)
+  processCwd: path.resolve(__dirname),
 });
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ By default the `process.cwd()` is used:
 ```js
 const { fileList } = await nodeFileTrace(files, {
   base: process.cwd()
-}
+});
 ```
 
 Any files/folders above the `base` are ignored in the listing and analysis.
@@ -52,7 +52,7 @@ Setting the `processCwd` option allows this analysis to be guided to the right p
 ```js
 const { fileList } = await nodeFileTrace(files, {
   processCwd: path.resolve(__dirname)
-}
+});
 ```
 
 By default `processCwd` is the same as `base`.


### PR DESCRIPTION
I just added parentheses to the functions that were missing them.

**Old:**

```js
const { fileList } = await nodeFileTrace(files, {
  base: process.cwd()
}
```

```js
const { fileList } = await nodeFileTrace(files, {
  processCwd: path.resolve(__dirname)
}
```

**New:**

```js
const { fileList } = await nodeFileTrace(files, {
  base: process.cwd()
});
```

```js
const { fileList } = await nodeFileTrace(files, {
  processCwd: path.resolve(__dirname)
});
```
