### PR TITLE
fix: Support browser overrides in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
         "@google-cloud/bigquery": "^4.1.4",
         "@google-cloud/firestore": "^7.6.0",
+        "@opentelemetry/api": "^1.7.0",
         "@sentry/node": "^5.5.0",
         "@tpluscode/sparql-builder": "^0.3.12",
         "@types/bindings": "^1.3.0",
@@ -3950,6 +3951,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+      "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@phc/format": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "@google-cloud/bigquery": "^4.1.4",
     "@google-cloud/firestore": "^7.6.0",
+    "@opentelemetry/api": "^1.7.0",
     "@sentry/node": "^5.5.0",
     "@tpluscode/sparql-builder": "^0.3.12",
     "@types/bindings": "^1.3.0",

--- a/src/node-file-trace.ts
+++ b/src/node-file-trace.ts
@@ -68,6 +68,7 @@ export class Job {
   public warnings: Set<Error>;
   public reasons: NodeFileTraceReasons = new Map();
   private cachedFileSystem: CachedFileSystem;
+  private remappings: Map<string, Set<string>> = new Map();
 
   constructor({
     base = process.cwd(),
@@ -152,6 +153,16 @@ export class Job {
     this.esmFileList = new Set();
     this.processed = new Set();
     this.warnings = new Set();
+  }
+
+  addRemapping(path: string, dep: string) {
+    if (path === dep) return;
+    let deps = this.remappings.get(path);
+    if (!deps) {
+      deps = new Set();
+      this.remappings.set(path, deps);
+    }
+    deps.add(dep);
   }
 
   async readlink(path: string) {
@@ -315,6 +326,14 @@ export class Job {
       return;
     }
     this.processed.add(path);
+
+    // Additional dependencies.
+    const additionalDeps = this.remappings.get(path);
+    if (additionalDeps) {
+      await Promise.all(
+        [...additionalDeps].map(async (dep) => this.emitDependency(dep, path)),
+      );
+    }
 
     const emitted = await this.emitFile(path, 'dependency', parent);
     if (!emitted) return;

--- a/src/resolve-dependency.ts
+++ b/src/resolve-dependency.ts
@@ -387,7 +387,7 @@ async function resolvePackage(
     if (pkgCfg) {
       await resolveRemappings(
         nodeModulesDir + sep + pkgName,
-        pkgCfg ?? {},
+        pkgCfg,
         parent,
         job,
       );

--- a/test/integration/otel-api.js
+++ b/test/integration/otel-api.js
@@ -1,0 +1,3 @@
+const { trace } = require('@opentelemetry/api');
+
+void trace.getTracer('test').startSpan('test');

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -129,9 +129,20 @@ for (const { testName, isRoot } of unitTests) {
         inputFileNames.push('input-2.js', 'input-3.js', 'input-4.js');
       }
 
+      // Type: { conditions?: string[] }
+      let testOpts = {};
+      try {
+        testOpts = JSON.parse(
+          fs.readFileSync(join(unitPath, 'test-opts.json')).toString(),
+        );
+      } catch {
+        // Ignore.
+      }
+
       const { fileList, reasons } = await nodeFileTrace(
         inputFileNames.map((file) => join(unitPath, file)),
         {
+          conditions: testOpts.conditions,
           base: isRoot ? '/' : `${__dirname}/../`,
           processCwd: unitPath,
           paths: {

--- a/test/unit/browser-remappings-disabled/.gitignore
+++ b/test/unit/browser-remappings-disabled/.gitignore
@@ -1,0 +1,2 @@
+# include node_modules for testing
+!node_modules 

--- a/test/unit/browser-remappings-disabled/input.js
+++ b/test/unit/browser-remappings-disabled/input.js
@@ -1,0 +1,2 @@
+require('pkg');
+

--- a/test/unit/browser-remappings-disabled/node_modules/pkg/index.js
+++ b/test/unit/browser-remappings-disabled/node_modules/pkg/index.js
@@ -1,0 +1,1 @@
+module.exports = 'legacy index';

--- a/test/unit/browser-remappings-disabled/node_modules/pkg/package.json
+++ b/test/unit/browser-remappings-disabled/node_modules/pkg/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "pkg",
+  "main": "index.js",
+  "exports": {
+    ".": {
+      "import": "./subdir/import-main.js",
+      "require": "./require-main.cjs"
+    },
+    "./asdf": {
+      "import": "./subdir/import-main.js"
+    }
+  },
+  "browser": {
+    "./subdir/import-main.js": "./subdir/import-main-browser.js"
+  }
+}

--- a/test/unit/browser-remappings-disabled/node_modules/pkg/require-main.cjs
+++ b/test/unit/browser-remappings-disabled/node_modules/pkg/require-main.cjs
@@ -1,0 +1,2 @@
+import('pkg/asdf');
+module.exports = 'require main';

--- a/test/unit/browser-remappings-disabled/node_modules/pkg/subdir/import-main-browser.js
+++ b/test/unit/browser-remappings-disabled/node_modules/pkg/subdir/import-main-browser.js
@@ -1,0 +1,1 @@
+export default 'import main browser';

--- a/test/unit/browser-remappings-disabled/node_modules/pkg/subdir/import-main.js
+++ b/test/unit/browser-remappings-disabled/node_modules/pkg/subdir/import-main.js
@@ -1,0 +1,1 @@
+export default 'import main';

--- a/test/unit/browser-remappings-disabled/node_modules/pkg/subdir/package.json
+++ b/test/unit/browser-remappings-disabled/node_modules/pkg/subdir/package.json
@@ -1,0 +1,1 @@
+{"type": "module"}

--- a/test/unit/browser-remappings-disabled/output.js
+++ b/test/unit/browser-remappings-disabled/output.js
@@ -1,0 +1,9 @@
+[
+  "package.json",
+  "test/unit/browser-remappings-disabled/input.js",
+  "test/unit/browser-remappings-disabled/node_modules/pkg/index.js",
+  "test/unit/browser-remappings-disabled/node_modules/pkg/package.json",
+  "test/unit/browser-remappings-disabled/node_modules/pkg/require-main.cjs",
+  "test/unit/browser-remappings-disabled/node_modules/pkg/subdir/import-main.js",
+  "test/unit/browser-remappings-disabled/node_modules/pkg/subdir/package.json"
+]

--- a/test/unit/browser-remappings-disabled/test-opts.json
+++ b/test/unit/browser-remappings-disabled/test-opts.json
@@ -1,0 +1,3 @@
+{
+  "conditions": ["node"]
+}

--- a/test/unit/browser-remappings-malformed/.gitignore
+++ b/test/unit/browser-remappings-malformed/.gitignore
@@ -1,0 +1,2 @@
+# include node_modules for testing
+!node_modules 

--- a/test/unit/browser-remappings-malformed/input.js
+++ b/test/unit/browser-remappings-malformed/input.js
@@ -1,0 +1,2 @@
+require('pkg');
+

--- a/test/unit/browser-remappings-malformed/node_modules/pkg/index.js
+++ b/test/unit/browser-remappings-malformed/node_modules/pkg/index.js
@@ -1,0 +1,1 @@
+module.exports = 'legacy index';

--- a/test/unit/browser-remappings-malformed/node_modules/pkg/package.json
+++ b/test/unit/browser-remappings-malformed/node_modules/pkg/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "pkg",
+  "main": "index.js",
+  "exports": {
+    ".": {
+      "import": "./subdir/import-main.js",
+      "require": "./require-main.cjs"
+    },
+    "./asdf": {
+      "import": "./subdir/import-main.js"
+    }
+  },
+  "browser": "./subdir/import-main-browser.js"
+}

--- a/test/unit/browser-remappings-malformed/node_modules/pkg/require-main.cjs
+++ b/test/unit/browser-remappings-malformed/node_modules/pkg/require-main.cjs
@@ -1,0 +1,2 @@
+import('pkg/asdf');
+module.exports = 'require main';

--- a/test/unit/browser-remappings-malformed/node_modules/pkg/subdir/import-main-browser.js
+++ b/test/unit/browser-remappings-malformed/node_modules/pkg/subdir/import-main-browser.js
@@ -1,0 +1,1 @@
+export default 'import main browser';

--- a/test/unit/browser-remappings-malformed/node_modules/pkg/subdir/import-main.js
+++ b/test/unit/browser-remappings-malformed/node_modules/pkg/subdir/import-main.js
@@ -1,0 +1,1 @@
+export default 'import main';

--- a/test/unit/browser-remappings-malformed/node_modules/pkg/subdir/package.json
+++ b/test/unit/browser-remappings-malformed/node_modules/pkg/subdir/package.json
@@ -1,0 +1,1 @@
+{"type": "module"}

--- a/test/unit/browser-remappings-malformed/output.js
+++ b/test/unit/browser-remappings-malformed/output.js
@@ -1,0 +1,9 @@
+[
+  "package.json",
+  "test/unit/browser-remappings-malformed/input.js",
+  "test/unit/browser-remappings-malformed/node_modules/pkg/index.js",
+  "test/unit/browser-remappings-malformed/node_modules/pkg/package.json",
+  "test/unit/browser-remappings-malformed/node_modules/pkg/require-main.cjs",
+  "test/unit/browser-remappings-malformed/node_modules/pkg/subdir/import-main.js",
+  "test/unit/browser-remappings-malformed/node_modules/pkg/subdir/package.json"
+]

--- a/test/unit/browser-remappings-malformed/test-opts.json
+++ b/test/unit/browser-remappings-malformed/test-opts.json
@@ -1,0 +1,3 @@
+{
+  "conditions": ["browser"]
+}

--- a/test/unit/browser-remappings-malformed2/.gitignore
+++ b/test/unit/browser-remappings-malformed2/.gitignore
@@ -1,0 +1,2 @@
+# include node_modules for testing
+!node_modules 

--- a/test/unit/browser-remappings-malformed2/input.js
+++ b/test/unit/browser-remappings-malformed2/input.js
@@ -1,0 +1,2 @@
+require('pkg');
+

--- a/test/unit/browser-remappings-malformed2/node_modules/pkg/index.js
+++ b/test/unit/browser-remappings-malformed2/node_modules/pkg/index.js
@@ -1,0 +1,1 @@
+module.exports = 'legacy index';

--- a/test/unit/browser-remappings-malformed2/node_modules/pkg/package.json
+++ b/test/unit/browser-remappings-malformed2/node_modules/pkg/package.json
@@ -11,7 +11,7 @@
     }
   },
   "browser": {
-    "./subdir/import-main.js": "./subdir/import-main-browser.js",
-    "./unknown.js": "./invalid.js"
+    "./subdir/import-main.js": "./invalid.js",
+    "./invalid.js": "./subdir/import-main-browser.js"
   }
 }

--- a/test/unit/browser-remappings-malformed2/node_modules/pkg/package.json
+++ b/test/unit/browser-remappings-malformed2/node_modules/pkg/package.json
@@ -12,6 +12,9 @@
   },
   "browser": {
     "./subdir/import-main.js": "./invalid.js",
-    "./invalid.js": "./subdir/import-main-browser.js"
+    "./require-main.cjs": "invalid.js",
+    "./invalid.js": "./subdir/import-main-browser.js",
+    "invalid.js": "./subdir/import-main-browser.js",
+    "invalid2.js": "unknown.js"
   }
 }

--- a/test/unit/browser-remappings-malformed2/node_modules/pkg/require-main.cjs
+++ b/test/unit/browser-remappings-malformed2/node_modules/pkg/require-main.cjs
@@ -1,0 +1,2 @@
+import('pkg/asdf');
+module.exports = 'require main';

--- a/test/unit/browser-remappings-malformed2/node_modules/pkg/subdir/import-main-browser.js
+++ b/test/unit/browser-remappings-malformed2/node_modules/pkg/subdir/import-main-browser.js
@@ -1,0 +1,1 @@
+export default 'import main browser';

--- a/test/unit/browser-remappings-malformed2/node_modules/pkg/subdir/import-main.js
+++ b/test/unit/browser-remappings-malformed2/node_modules/pkg/subdir/import-main.js
@@ -1,0 +1,1 @@
+export default 'import main';

--- a/test/unit/browser-remappings-malformed2/node_modules/pkg/subdir/package.json
+++ b/test/unit/browser-remappings-malformed2/node_modules/pkg/subdir/package.json
@@ -1,0 +1,1 @@
+{"type": "module"}

--- a/test/unit/browser-remappings-malformed2/output.js
+++ b/test/unit/browser-remappings-malformed2/output.js
@@ -1,9 +1,9 @@
 [
   "package.json",
-  "test/unit/browser-remappings-malformed/input.js",
-  "test/unit/browser-remappings-malformed/node_modules/pkg/index.js",
-  "test/unit/browser-remappings-malformed/node_modules/pkg/package.json",
-  "test/unit/browser-remappings-malformed/node_modules/pkg/require-main.cjs",
-  "test/unit/browser-remappings-malformed/node_modules/pkg/subdir/import-main.js",
-  "test/unit/browser-remappings-malformed/node_modules/pkg/subdir/package.json"
+  "test/unit/browser-remappings-malformed2/input.js",
+  "test/unit/browser-remappings-malformed2/node_modules/pkg/index.js",
+  "test/unit/browser-remappings-malformed2/node_modules/pkg/package.json",
+  "test/unit/browser-remappings-malformed2/node_modules/pkg/require-main.cjs",
+  "test/unit/browser-remappings-malformed2/node_modules/pkg/subdir/import-main.js",
+  "test/unit/browser-remappings-malformed2/node_modules/pkg/subdir/package.json"
 ]

--- a/test/unit/browser-remappings-malformed2/output.js
+++ b/test/unit/browser-remappings-malformed2/output.js
@@ -1,0 +1,9 @@
+[
+  "package.json",
+  "test/unit/browser-remappings-malformed/input.js",
+  "test/unit/browser-remappings-malformed/node_modules/pkg/index.js",
+  "test/unit/browser-remappings-malformed/node_modules/pkg/package.json",
+  "test/unit/browser-remappings-malformed/node_modules/pkg/require-main.cjs",
+  "test/unit/browser-remappings-malformed/node_modules/pkg/subdir/import-main.js",
+  "test/unit/browser-remappings-malformed/node_modules/pkg/subdir/package.json"
+]

--- a/test/unit/browser-remappings-malformed2/test-opts.json
+++ b/test/unit/browser-remappings-malformed2/test-opts.json
@@ -1,0 +1,3 @@
+{
+  "conditions": ["browser"]
+}

--- a/test/unit/browser-remappings/.gitignore
+++ b/test/unit/browser-remappings/.gitignore
@@ -1,0 +1,2 @@
+# include node_modules for testing
+!node_modules 

--- a/test/unit/browser-remappings/input.js
+++ b/test/unit/browser-remappings/input.js
@@ -1,0 +1,2 @@
+require('pkg');
+

--- a/test/unit/browser-remappings/node_modules/pkg/index.js
+++ b/test/unit/browser-remappings/node_modules/pkg/index.js
@@ -1,0 +1,1 @@
+module.exports = 'legacy index';

--- a/test/unit/browser-remappings/node_modules/pkg/package.json
+++ b/test/unit/browser-remappings/node_modules/pkg/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "pkg",
+  "main": "index.js",
+  "exports": {
+    ".": {
+      "import": "./subdir/import-main.js",
+      "require": "./require-main.cjs"
+    },
+    "./asdf": {
+      "import": "./subdir/import-main.js"
+    }
+  },
+  "browser": {
+    "./subdir/import-main.js": "./subdir/import-main-browser.js"
+  }
+}

--- a/test/unit/browser-remappings/node_modules/pkg/require-main.cjs
+++ b/test/unit/browser-remappings/node_modules/pkg/require-main.cjs
@@ -1,0 +1,2 @@
+import('pkg/asdf');
+module.exports = 'require main';

--- a/test/unit/browser-remappings/node_modules/pkg/subdir/import-main-browser.js
+++ b/test/unit/browser-remappings/node_modules/pkg/subdir/import-main-browser.js
@@ -1,0 +1,1 @@
+export default 'import main browser';

--- a/test/unit/browser-remappings/node_modules/pkg/subdir/import-main.js
+++ b/test/unit/browser-remappings/node_modules/pkg/subdir/import-main.js
@@ -1,0 +1,1 @@
+export default 'import main';

--- a/test/unit/browser-remappings/node_modules/pkg/subdir/package.json
+++ b/test/unit/browser-remappings/node_modules/pkg/subdir/package.json
@@ -1,0 +1,1 @@
+{"type": "module"}

--- a/test/unit/browser-remappings/output.js
+++ b/test/unit/browser-remappings/output.js
@@ -1,0 +1,10 @@
+[
+  "package.json",
+  "test/unit/browser-remappings/input.js",
+  "test/unit/browser-remappings/node_modules/pkg/index.js",
+  "test/unit/browser-remappings/node_modules/pkg/package.json",
+  "test/unit/browser-remappings/node_modules/pkg/require-main.cjs",
+  "test/unit/browser-remappings/node_modules/pkg/subdir/import-main-browser.js",
+  "test/unit/browser-remappings/node_modules/pkg/subdir/import-main.js",
+  "test/unit/browser-remappings/node_modules/pkg/subdir/package.json"
+]

--- a/test/unit/browser-remappings/test-opts.json
+++ b/test/unit/browser-remappings/test-opts.json
@@ -1,0 +1,3 @@
+{
+  "conditions": ["browser"]
+}


### PR DESCRIPTION
`browser` section `package.json` is used to expand a list of dependent files. The downstream build tool would normally do the right thing and use the `browser` section for bundling correctly. I tested the bundling itself on esbuild and WebPack, and it works correctly. All that's needed is to make sure the files are there.