### PR TITLE
fix: add special case for `geoip-lite`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "firebase-admin": "^12.0.0",
         "fluent-ffmpeg": "^2.1.2",
         "geo-tz": "^7.0.1",
+        "geoip-lite": "^1.4.10",
         "graphql": "^14.4.2",
         "highlights": "^3.1.6",
         "hot-shots": "^6.3.0",
@@ -13936,6 +13937,46 @@
         "typedarray": "^0.0.6"
       }
     },
+    "node_modules/geoip-lite": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/geoip-lite/-/geoip-lite-1.4.10.tgz",
+      "integrity": "sha512-4N69uhpS3KFd97m00wiFEefwa+L+HT5xZbzPhwu+sDawStg6UN/dPwWtUfkQuZkGIY1Cj7wDVp80IsqNtGMi2w==",
+      "dev": true,
+      "dependencies": {
+        "async": "2.1 - 2.6.4",
+        "chalk": "4.1 - 4.1.2",
+        "iconv-lite": "0.4.13 - 0.6.3",
+        "ip-address": "5.8.9 - 5.9.4",
+        "lazy": "1.0.11",
+        "rimraf": "2.5.2 - 2.7.1",
+        "yauzl": "2.9.2 - 2.10.0"
+      },
+      "engines": {
+        "node": ">=10.3.0"
+      }
+    },
+    "node_modules/geoip-lite/node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/geoip-lite/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
     "node_modules/get-assigned-identifiers": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
@@ -15972,6 +16013,32 @@
         "type": "opencollective",
         "url": "https://opencollective.com/ioredis"
       }
+    },
+    "node_modules/ip-address": {
+      "version": "5.9.4",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.9.4.tgz",
+      "integrity": "sha512-dHkI3/YNJq4b/qQaz+c8LuarD3pY24JqZWfjB8aZx1gtpc2MDILu9L9jpZe1sHpzo/yWFweQVn+U//FhazUxmw==",
+      "dev": true,
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "lodash": "^4.17.15",
+        "sprintf-js": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/ip-address/node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true
+    },
+    "node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+      "dev": true
     },
     "node_modules/ip-regex": {
       "version": "2.1.0",
@@ -18527,6 +18594,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/lazy": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz",
+      "integrity": "sha512-Y+CjUfLmIpoUCCRl0ub4smrYtGGr5AOa2AKOaWelGHOGz33X/Y/KizefGqbkwfz44+cnq/+9habclf8vOmu2LA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.2.0"
       }
     },
     "node_modules/lazy-cache": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "firebase-admin": "^12.0.0",
     "fluent-ffmpeg": "^2.1.2",
     "geo-tz": "^7.0.1",
+    "geoip-lite": "^1.4.10",
     "graphql": "^14.4.2",
     "highlights": "^3.1.6",
     "hot-shots": "^6.3.0",

--- a/src/utils/special-cases.ts
+++ b/src/utils/special-cases.ts
@@ -333,6 +333,15 @@ const specialCases: Record<string, (o: SpecialCaseOpts) => void> = {
       emitDependency(resolve(dirname(id), 'bin/pixelmatch'));
     }
   },
+  'geoip-lite'({ id, emitAsset }) {
+    if (id.endsWith('geoip-lite/lib/geoip.js')) {
+      emitAsset(resolve(dirname(id), '../data/geoip-city.dat'));
+      emitAsset(resolve(dirname(id), '../data/geoip-city6.dat'));
+      emitAsset(resolve(dirname(id), '../data/geoip-city-names.dat'));
+      emitAsset(resolve(dirname(id), '../data/geoip-country.dat'));
+      emitAsset(resolve(dirname(id), '../data/geoip-country6.dat'));
+    }
+  },
 };
 
 interface SpecialCaseOpts {

--- a/test/integration/geoip-lite.js
+++ b/test/integration/geoip-lite.js
@@ -1,0 +1,4 @@
+const geoip = require('geoip-lite');
+
+const ip = "207.97.227.239";
+const geo = geoip.lookup(ip);


### PR DESCRIPTION
Currently, nft can not handle data assets of `geoip-lite` package properly. Error message like below ⬇️

<img width="1333" alt="image" src="https://github.com/user-attachments/assets/3fe76911-33e2-4b3d-8a20-245c1e79567c">

Test Code

```js
const geoip = require('geoip-lite');

const ip = "207.97.227.239";
const geo = geoip.lookup(ip);
```

This PR adds essential data files as assets for `geoip-lite` in special-case to solve it.

