### PR TITLE
Show error which occurs in vercel/vercel ci tests

### DIFF
--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -66,7 +66,8 @@ function resetFileIOMocks() {
 
 afterEach(resetFileIOMocks);
 
-for (const { testName, isRoot } of unitTests) {
+const unitTests2 = [{ testName: 'a-url-error', isRoot: false }];
+for (const { testName, isRoot } of unitTests2) {
   const testSuffix = `${testName} from ${isRoot ? 'root' : 'cwd'}`;
   if (
     process.platform === 'win32' &&

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -66,8 +66,7 @@ function resetFileIOMocks() {
 
 afterEach(resetFileIOMocks);
 
-const unitTests2 = [{ testName: 'a-url-error', isRoot: false }];
-for (const { testName, isRoot } of unitTests2) {
+for (const { testName, isRoot } of unitTests) {
   const testSuffix = `${testName} from ${isRoot ? 'root' : 'cwd'}`;
   if (
     process.platform === 'win32' &&

--- a/test/unit/a-url-error/input.js
+++ b/test/unit/a-url-error/input.js
@@ -1,1 +1,1 @@
-const URLParser = typeof URL === 'undefined' ? require('url').URL : URL;
+const URLParser = typeof window === 'undefined' ? URL : 'b'

--- a/test/unit/a-url-error/input.js
+++ b/test/unit/a-url-error/input.js
@@ -1,0 +1,1 @@
+const URLParser = typeof URL === 'undefined' ? require('url').URL : URL;


### PR DESCRIPTION
We're seeing an error with `0.27.4` in our tests while trying to upgrade

https://github.com/vercel/vercel/actions/runs/11487918780/job/31973631387?pr=12109

I was able to isolate it down to this code snippet. Which is from an admittedly old module depended upon by Next version 9

https://www.npmjs.com/package/normalize-url/v/3.3.0?activeTab=code

