### PR TITLE
chore(test): update ecmascript tests

### DIFF
--- a/test/ecmascript.test.js
+++ b/test/ecmascript.test.js
@@ -19,6 +19,8 @@ const ignoreCategories = new Set([
   'Generator function.sent Meta Property',
   'Class and Property Decorators',
   'throw expressions',
+  'RegExp Pattern Modifiers',
+  'Duplicate named capturing groups',
 ]);
 
 async function runTests(importPath) {

--- a/test/ecmascript/data-es2016plus.js
+++ b/test/ecmascript/data-es2016plus.js
@@ -22,8 +22,8 @@ exports.tests = [
       {
         name: 'basic support',
         exec: function () {/*
-         return 2 ** 3 === 8 && -(5 ** 2) === -25 && (-5) ** 2 === 25;
-         */},
+          return 2 ** 3 === 8 && -(5 ** 2) === -25 && (-5) ** 2 === 25;
+        */},
         res: {
           tr: true,
           babel6corejs2: true,
@@ -51,8 +51,8 @@ exports.tests = [
       {
         name: 'assignment',
         exec: function () {/*
-         var a = 2; a **= 3; return a === 8;
-         */},
+          var a = 2; a **= 3; return a === 8;
+        */},
         res: {
           tr: true,
           babel6corejs2: true,
@@ -80,13 +80,13 @@ exports.tests = [
       {
         name: 'early syntax error for unary negation without parens',
         exec: function () {/*
-         if (2 ** 3 !== 8) { return false; }
-         try {
-         Function("-5 ** 2")();
-         } catch(e) {
-         return true;
-         }
-         */},
+          if (2 ** 3 !== 8) { return false; }
+          try {
+            Function ("-5 ** 2")();
+          } catch (e) {
+            return true;
+          }
+        */},
         res: {
           babel6corejs2: true,
           closure: true,
@@ -122,11 +122,13 @@ exports.tests = [
         category: '2017 features',
         significance: 'medium',
         exec: function () {/*
-         var obj = Object.create({ a: "qux", d: "qux" });
-         obj.a = "foo"; obj.b = "bar"; obj.c = "baz";
-         var v = Object.values(obj);
-         return Array.isArray(v) && String(v) === "foo,bar,baz";
-         */},
+          var obj = Object.create({ a: "qux", d: "qux" });
+          obj.a = "foo";
+          obj.b = "bar";
+          obj.c = "baz";
+          var v = Object.values(obj);
+          return Array.isArray(v) && String(v) === "foo,bar,baz";
+        */},
         res: {
           babel6corejs2: babel.corejs,
           closure: true,
@@ -156,15 +158,17 @@ exports.tests = [
         spec: 'https://tc39.github.io/ecma262/#sec-object.entries',
         mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries',
         exec: function () {/*
-         var obj = Object.create({ a: "qux", d: "qux" });
-         obj.a = "foo"; obj.b = "bar"; obj.c = "baz";
-         var e = Object.entries(obj);
-         return Array.isArray(e)
-         && e.length === 3
-         && String(e[0]) === "a,foo"
-         && String(e[1]) === "b,bar"
-         && String(e[2]) === "c,baz";
-         */},
+          var obj = Object.create({ a: "qux", d: "qux" });
+          obj.a = "foo";
+          obj.b = "bar";
+          obj.c = "baz";
+          var e = Object.entries(obj);
+          return Array.isArray(e)
+            && e.length === 3
+            && String(e[0]) === "a,foo"
+            && String(e[1]) === "b,bar"
+            && String(e[2]) === "c,baz";
+        */},
         res: {
           babel6corejs2: babel.corejs,
           closure: true,
@@ -201,9 +205,9 @@ exports.tests = [
           var D = Object.getOwnPropertyDescriptors(O);
 
           return D.a.value === 1 && D.a.enumerable === true && D.a.configurable === true && D.a.writable === true
-          && D[B].value === 2 && D[B].enumerable === true && D[B].configurable === true && D[B].writable === true
-          && D.c.value === 3 && D.c.enumerable === false && D.c.configurable === false && D.c.writable === false;
-          */},
+            && D[B].value === 2 && D[B].enumerable === true && D[B].configurable === true && D[B].writable === true
+            && D.c.value === 3 && D.c.enumerable === false && D.c.configurable === false && D.c.writable === false;
+        */},
         res: {
           babel6corejs2: babel.corejs,
           closure: true,
@@ -223,14 +227,15 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: true,
           reactnative0_70_3: true,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          rhino1_7_15: true,
         }
       },
       {
         name: "Object.getOwnPropertyDescriptors doesn't provide undefined descriptors",
         exec: function () {/*
-          var P = new Proxy({a:1}, {
-            getOwnPropertyDescriptor: function(t, k) {}
+          var P = new Proxy({ a: 1 }, {
+            getOwnPropertyDescriptor: function (t, k) {}
           });
           return !Object.getOwnPropertyDescriptors(P).hasOwnProperty('a');
         */},
@@ -265,12 +270,12 @@ exports.tests = [
       {
         name: 'Array.prototype.includes',
         mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes',
-        exec: function(){/*
-         return [1, 2, 3].includes(1)
-         && ![1, 2, 3].includes(4)
-         && ![1, 2, 3].includes(1, 1)
-         && [NaN].includes(NaN);
-         */},
+        exec: function () {/*
+          return [1, 2, 3].includes(1)
+            && ![1, 2, 3].includes(4)
+            && ![1, 2, 3].includes(1, 1)
+            && [NaN].includes(NaN);
+        */},
         res: {
           babel6corejs2: babel.corejs,
           closure: true,
@@ -295,10 +300,10 @@ exports.tests = [
       {
         name: 'Array.prototype.includes handles sparse arrays',
         mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes',
-        exec: function(){/*
-         return [,].includes()
-          && Array(1).includes();
-         */},
+        exec: function () {/*
+          return [,].includes()
+            && Array(1).includes();
+        */},
         res: {
           babel6corejs2: babel.corejs,
           closure: true,
@@ -324,31 +329,35 @@ exports.tests = [
       },
       {
         name: 'Array.prototype.includes is generic',
-        exec: function(){/*
-         var passed = 0;
-         return [].includes.call({
-         get "0"() {
-         passed = NaN;
-         return 'foo';
-         },
-         get "11"() {
-         passed += 1;
-         return 0;
-         },
-         get "19"() {
-         passed += 1;
-         return 'foo';
-         },
-         get "21"() {
-         passed = NaN;
-         return 'foo';
-         },
-         get length() {
-         passed += 1;
-         return 24;
-         }
-         }, 'foo', 6) === true && passed === 3;
-         */},
+        exec: function () {/*
+          var passed = 0;
+          return [].includes.call(
+            {
+              get "0"() {
+                passed = NaN;
+                return 'foo';
+              },
+              get "11"() {
+                passed += 1;
+                return 0;
+              },
+              get "19"() {
+                passed += 1;
+                return 'foo';
+              },
+              get "21"() {
+                passed = NaN;
+                return 'foo';
+              },
+              get length() {
+                passed += 1;
+                return 24;
+              }
+            },
+            'foo',
+            6
+          ) === true && passed === 3;
+        */},
         res: {
           babel6corejs2: babel.corejs,
           closure: false,
@@ -375,13 +384,22 @@ exports.tests = [
       {
         name: '%TypedArray%.prototype.includes',
         mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/includes',
-        exec: function(){/*
-         return [Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array,
-         Int32Array, Uint32Array, Float32Array, Float64Array].every(function(TypedArray){
-         return new TypedArray([1, 2, 3]).includes(1)
-         && !new TypedArray([1, 2, 3]).includes(4)
-         && !new TypedArray([1, 2, 3]).includes(1, 1);
-         });
+        exec: function () {/*
+          return [
+            Int8Array,
+            Uint8Array,
+            Uint8ClampedArray,
+            Int16Array,
+            Uint16Array,
+            Int32Array,
+            Uint32Array,
+            Float32Array,
+            Float64Array
+          ].every(function (TypedArray) {
+            return new TypedArray([1, 2, 3]).includes(1)
+            && !new TypedArray([1, 2, 3]).includes(4)
+            && !new TypedArray([1, 2, 3]).includes(1, 1);
+          });
          */},
         res: {
           babel6corejs2: babel.corejs,
@@ -414,13 +432,13 @@ exports.tests = [
         name: 'String.prototype.padStart',
         spec: 'https://tc39.github.io/ecma262/#sec-string.prototype.padstart',
         mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart',
-        exec: function(){/*
-         return 'hello'.padStart(10) === '     hello'
-         && 'hello'.padStart(10, '1234') === '12341hello'
-         && 'hello'.padStart() === 'hello'
-         && 'hello'.padStart(6, '123') === '1hello'
-         && 'hello'.padStart(3) === 'hello'
-         && 'hello'.padStart(3, '123') === 'hello';
+        exec: function () {/*
+          return 'hello'.padStart(10) === '     hello'
+            && 'hello'.padStart(10, '1234') === '12341hello'
+            && 'hello'.padStart() === 'hello'
+            && 'hello'.padStart(6, '123') === '1hello'
+            && 'hello'.padStart(3) === 'hello'
+            && 'hello'.padStart(3, '123') === 'hello';
          */},
         res: {
           babel6corejs2: babel.corejs,
@@ -450,13 +468,13 @@ exports.tests = [
         name: 'String.prototype.padEnd',
         spec: 'https://tc39.github.io/ecma262/#sec-string.prototype.padend',
         mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd',
-        exec: function(){/*
-         return 'hello'.padEnd(10) === 'hello     '
-         && 'hello'.padEnd(10, '1234') === 'hello12341'
-         && 'hello'.padEnd() === 'hello'
-         && 'hello'.padEnd(6, '123') === 'hello1'
-         && 'hello'.padEnd(3) === 'hello'
-         && 'hello'.padEnd(3, '123') === 'hello';
+        exec: function () {/*
+          return 'hello'.padEnd(10) === 'hello     '
+            && 'hello'.padEnd(10, '1234') === 'hello12341'
+            && 'hello'.padEnd() === 'hello'
+            && 'hello'.padEnd(6, '123') === 'hello1'
+            && 'hello'.padEnd(3) === 'hello'
+            && 'hello'.padEnd(3, '123') === 'hello';
          */},
         res: {
           babel6corejs2: babel.corejs,
@@ -494,8 +512,8 @@ exports.tests = [
       {
         name: 'in parameter lists',
         mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#Parameter_definitions',
-        exec: function(){/*
-          return typeof function f( a, b, ){} === 'function';
+        exec: function () {/*
+          return typeof function f( a, b, ) {} === 'function';
         */},
         res: {
           babel6corejs2: true,
@@ -516,13 +534,14 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: true,
           reactnative0_70_3: true,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          rhino1_7_15: true,
         }
       },
       {
         name: 'in argument lists',
         mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#Function_calls',
-        exec: function(){/*
+        exec: function () {/*
           return Math.min(1,2,3,) === 1;
         */},
         res: {
@@ -560,14 +579,14 @@ exports.tests = [
         // that (without await) resolve to the returned value.
         name: 'return',
         exec: function () {/*
-          async function a(){
+          async function a() {
             return "foo";
           }
           var p = a();
           if (!(p instanceof Promise)) {
             return false;
           }
-          p.then(function(result) {
+          p.then(function (result) {
             if (result === "foo") {
               asyncTestPassed();
             }
@@ -599,14 +618,14 @@ exports.tests = [
       {
         name: 'throw',
         exec: function () {/*
-          async function a(){
+          async function a() {
             throw "foo";
           }
           var p = a();
           if (!(p instanceof Promise)) {
             return false;
           }
-          p.catch(function(result) {
+          p.catch (function (result) {
             if (result === "foo") {
               asyncTestPassed();
             }
@@ -640,8 +659,8 @@ exports.tests = [
       {
         name: 'no line break between async and function',
         exec: function () {/*
-          async function a(){}
-          try { Function("async\n function a(){await 0}")(); } catch(e) { return true; }
+          async function a() {}
+          try { Function ("async\n function a() {await 0}")(); } catch (e) { return true; }
         */},
         res: {
           tr: null,
@@ -670,8 +689,8 @@ exports.tests = [
       },
       {
         name: 'no "prototype" property',
-        exec: function(){/*
-          async function a(){};
+        exec: function () {/*
+          async function a() {};
           return !a.hasOwnProperty("prototype");
         */},
         res: {
@@ -701,10 +720,10 @@ exports.tests = [
         name: 'await',
         mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await',
         exec: function () {/*
-          (async function (){
+          (async function () {
             await Promise.resolve();
-            var a1 = await new Promise(function(resolve) { setTimeout(resolve,800,"foo"); });
-            var a2 = await new Promise(function(resolve) { setTimeout(resolve,800,"bar"); });
+            var a1 = await new Promise(function (resolve) { setTimeout(resolve,800,"foo"); });
+            var a2 = await new Promise(function (resolve) { setTimeout(resolve,800,"bar"); });
             if (a1 + a2 === "foobar") {
               asyncTestPassed();
             }
@@ -736,11 +755,11 @@ exports.tests = [
       {
         name: 'await, rejection',
         exec: function () {/*
-          (async function (){
+          (async function () {
             await Promise.resolve();
             try {
-              var a1 = await new Promise(function(_, reject) { setTimeout(reject,800,"foo"); });
-            } catch(e) {
+              var a1 = await new Promise(function (_, reject) { setTimeout(reject,800,"foo"); });
+            } catch (e) {
               if (e === "foo") {
                 asyncTestPassed();
               }
@@ -774,8 +793,8 @@ exports.tests = [
       {
         name: 'must await a value',
         exec: function () {/*
-          async function a(){ await Promise.resolve(); }
-          try { Function("(async function a(){ await; }())")(); } catch(e) { return true; }
+          async function a() { await Promise.resolve(); }
+          try { Function ("(async function a() { await; }())")(); } catch (e) { return true; }
         */},
         res: {
           tr: null,
@@ -804,7 +823,7 @@ exports.tests = [
       {
         name: 'can await non-Promise values',
         exec: function () {/*
-          (async function (){
+          (async function () {
             await Promise.resolve();
             var e = await "foo";
             if (e === "foo") {
@@ -839,8 +858,8 @@ exports.tests = [
       {
         name: 'cannot await in parameters',
         exec: function () {/*
-          async function a(){ await Promise.resolve(); }
-          try { Function("(async function a(b = await Promise.resolve()){}())")(); } catch(e) { return true; }
+          async function a() { await Promise.resolve(); }
+          try { Function ("(async function a(b = await Promise.resolve()) {}())")(); } catch (e) { return true; }
         */},
         res: {
           tr: null,
@@ -870,13 +889,13 @@ exports.tests = [
         name: 'async methods, object literals',
         exec: function () {/*
           var o = {
-            async a(){ return await Promise.resolve("foo"); }
+            async a() { return await Promise.resolve("foo"); }
           };
           var p = o.a();
           if (!(p instanceof Promise)) {
             return false;
           }
-          p.then(function(result) {
+          p.then(function (result) {
             if (result === "foo") {
               asyncTestPassed();
             }
@@ -910,13 +929,13 @@ exports.tests = [
         name: 'async methods, classes',
         exec: function () {/*
           class C {
-            async a(){ return await Promise.resolve("foo"); }
+            async a() { return await Promise.resolve("foo"); }
           };
           var p = new C().a();
           if (!(p instanceof Promise)) {
             return false;
           }
-          p.then(function(result) {
+          p.then(function (result) {
             if (result === "foo") {
               asyncTestPassed();
             }
@@ -952,7 +971,7 @@ exports.tests = [
             callback();
           }
           class C {
-            a(){
+            a() {
               doSomething(async () => {
                 await 1;
                 asyncTestPassed();
@@ -993,7 +1012,7 @@ exports.tests = [
           if (!(p instanceof Promise)) {
             return false;
           }
-          p.then(function(result) {
+          p.then(function (result) {
             if (result === "foo") {
               asyncTestPassed();
             }
@@ -1023,9 +1042,9 @@ exports.tests = [
       },
       {
         name: 'correct prototype chain',
-        exec: function() {/*
-          var asyncFunctionProto = Object.getPrototypeOf(async function (){});
-          return asyncFunctionProto !== function(){}.prototype
+        exec: function () {/*
+          var asyncFunctionProto = Object.getPrototypeOf(async function () {});
+          return asyncFunctionProto !== function () {}.prototype
             && Object.getPrototypeOf(asyncFunctionProto) === Function.prototype;
         */},
         res: {
@@ -1055,8 +1074,8 @@ exports.tests = [
       },
       {
         name: 'async function prototype, Symbol.toStringTag',
-        exec: function() {/*
-          return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] === "AsyncFunction";
+        exec: function () {/*
+          return Object.getPrototypeOf(async function () {})[Symbol.toStringTag] === "AsyncFunction";
         */},
         res: {
           tr: null,
@@ -1084,13 +1103,13 @@ exports.tests = [
       },
       {
         name: 'async function constructor',
-        exec: function() {/*
-          var a = async function (){}.constructor("return 'foo';");
+        exec: function () {/*
+          var a = async function () {}.constructor("return 'foo';");
           var p = a();
           if (!(p instanceof Promise)) {
             return false;
           }
-          p.then(function(result) {
+          p.then(function (result) {
             if (result === "foo") {
               asyncTestPassed();
             }
@@ -1809,16 +1828,16 @@ exports.tests = [
         note_html: '<a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#67-new--generatorfunction">TC39 meeting notes from July 28, 2015.</a>'
       }
     ],
-    exec: function(){/*
-     function * generator() {
-     yield 3;
-     }
-     try {
-     new generator();
-     } catch(e) {
-     return true;
-     }
-     */},
+    exec: function () {/*
+      function * generator() {
+        yield 3;
+      }
+      try {
+        new generator();
+      } catch (e) {
+        return true;
+      }
+    */},
     res: {
       ie11: false,
       edge13: true,
@@ -1847,22 +1866,22 @@ exports.tests = [
         note_html: '<a href="https://github.com/tc39/ecma262/issues/293">\'Semantics of yield* in throw case\' GitHub issue in ECMA-262 repo.</a>'
       }
     ],
-    exec: function(){/*
-     function * generator() {
-     yield * (function * () {
-     try {
-     yield 'foo';
-     }
-     catch(e) {
-     return;
-     }
-     }());
-     yield 'bar';
-     }
-     var iter = generator();
-     iter.next();
-     return iter['throw']().value === 'bar';
-     */},
+    exec: function () {/*
+      function * generator() {
+        yield * (function * () {
+          try {
+            yield 'foo';
+          }
+          catch (e) {
+            return;
+          }
+        }());
+        yield 'bar';
+      }
+      var iter = generator();
+      iter.next();
+      return iter['throw']().value === 'bar';
+    */},
     res: {
       babel7corejs3: true,
       closure: false,
@@ -1896,13 +1915,13 @@ exports.tests = [
         note_html: '<a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-29.md#611-the-scope-of-use-strict-with-respect-to-destructuring-in-parameter-lists">TC39 meeting notes from July 29, 2015.</a>'
       }
     ],
-    exec: function(){/*
-     function foo(...a){}
-     try {
-     Function("function bar(...a){'use strict';}")();
-     } catch(e) {
-     return true;
-     }
+    exec: function () {/*
+      function foo(...a) {}
+      try {
+        Function ("function bar(...a) {'use strict';}")();
+      } catch (e) {
+      return true;
+      }
      */},
     res: {
       babel7corejs3: true,
@@ -1933,10 +1952,10 @@ exports.tests = [
         note_html: '<a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a>'
       }
     ],
-    exec: function(){/*
-     var [x, ...[y, ...z]] = [1,2,3,4];
-     return x === 1 && y === 2 && z + '' === '3,4';
-     */},
+    exec: function () {/*
+      var [x, ...[y, ...z]] = [1,2,3,4];
+      return x === 1 && y === 2 && z + '' === '3,4';
+    */},
     res: {
       babel6corejs2: true,
       closure: true,
@@ -1968,11 +1987,11 @@ exports.tests = [
         note_html: '<a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a>'
       }
     ],
-    exec: function(){/*
-     return function([x, ...[y, ...z]]) {
-     return x === 1 && y === 2 && z + '' === '3,4';
-     }([1,2,3,4]);
-     */},
+    exec: function () {/*
+      return function ([x, ...[y, ...z]]) {
+        return x === 1 && y === 2 && z + '' === '3,4';
+      }([1,2,3,4]);
+    */},
     res: {
       babel6corejs2: true,
       closure: true,
@@ -2005,16 +2024,16 @@ exports.tests = [
         note_html: '<a href="https://github.com/tc39/ecma262/pull/367">\'Normative: Remove [[Enumerate]] and associated reflective capabilities\' GitHub Pull Request in ECMA-262 repo.</a>'
       }
     ],
-    exec: function() {/*
-     var passed = true;
-     var proxy = new Proxy({}, {
-     enumerate: function() {
-     passed = false;
-     }
-     });
-     for(var key in proxy); // Should not throw, nor execute the 'enumerate' method.
-     return passed;
-     */},
+    exec: function () {/*
+      var passed = true;
+      var proxy = new Proxy({}, {
+        enumerate: function () {
+          passed = false;
+        }
+      });
+      for (var key in proxy); // Should not throw, nor execute the 'enumerate' method.
+      return passed;
+    */},
     res: {
       ie11: false,
       edge15: true,
@@ -2039,15 +2058,15 @@ exports.tests = [
     category: '2016 misc',
     significance: 'tiny',
     spec: 'http://www.ecma-international.org/ecma-262/7.0/index.html#sec-array.prototype.includes',
-    exec: function() {/*
+    exec: function () {/*
      // Array.prototype.includes -> Get -> [[Get]]
      var get = [];
-     var p = new Proxy({length: 3, 0: '', 1: '', 2: '', 3: ''}, { get: function(o, k) { get.push(k); return o[k]; }});
+     var p = new Proxy({length: 3, 0: '', 1: '', 2: '', 3: ''}, { get: function (o, k) { get.push(k); return o[k]; }});
      Array.prototype.includes.call(p, {});
      if (get + '' !== "length,0,1,2") return;
 
      get = [];
-     p = new Proxy({length: 4, 0: NaN, 1: '', 2: NaN, 3: ''}, { get: function(o, k) { get.push(k); return o[k]; }});
+     p = new Proxy({length: 4, 0: NaN, 1: '', 2: NaN, 3: ''}, { get: function (o, k) { get.push(k); return o[k]; }});
      Array.prototype.includes.call(p, NaN, 1);
      return (get + '' === "length,1,2");
      */},
@@ -2145,13 +2164,13 @@ exports.tests = [
       {
         name: '__defineGetter__, ToObject(this)',
         exec: function () {/*
-         var key = '__accessors_test__';
-         __defineGetter__.call(1, key, function(){});
-         try {
-         __defineGetter__.call(null, key, function(){});
-         } catch(e){
-         return true;
-         }
+          var key = '__accessors_test__';
+          __defineGetter__.call(1, key, function () {});
+          try {
+            __defineGetter__.call(null, key, function () {});
+          } catch (e) {
+          return true;
+          }
          */},
         res: {
           babel6corejs2: babel.corejs,
@@ -2249,10 +2268,10 @@ exports.tests = [
         name: '__defineSetter__, ToObject(this)',
         exec: function () {/*
          var key = '__accessors_test__';
-         __defineSetter__.call(1, key, function(){});
+         __defineSetter__.call(1, key, function () {});
          try {
-         __defineSetter__.call(null, key, function(){});
-         } catch(e){
+         __defineSetter__.call(null, key, function () {});
+         } catch (e) {
          return true;
          }
          */},
@@ -2354,16 +2373,16 @@ exports.tests = [
       {
         name: '__lookupGetter__, symbols',
         exec: function () {/*
-         var sym = Symbol();
-         var sym2 = Symbol();
-         var obj = {};
-         Object.defineProperty(obj, sym, { get: function() { return "bar"; }});
-         Object.defineProperty(obj, sym2, { value: 1 });
-         var foo = Object.prototype.__lookupGetter__.call(obj, sym);
-         return foo() === "bar"
-         && Object.prototype.__lookupGetter__.call(obj, sym2) === void undefined
-         && Object.prototype.__lookupGetter__.call(obj, Symbol()) === void undefined;
-         */},
+          var sym = Symbol();
+          var sym2 = Symbol();
+          var obj = {};
+          Object.defineProperty(obj, sym, { get: function () { return "bar"; }});
+          Object.defineProperty(obj, sym2, { value: 1 });
+          var foo = Object.prototype.__lookupGetter__.call(obj, sym);
+          return foo() === "bar"
+            && Object.prototype.__lookupGetter__.call(obj, sym2) === void undefined
+            && Object.prototype.__lookupGetter__.call(obj, Symbol()) === void undefined;
+        */},
         res: {
           babel6corejs2: babel.corejs,
           typescript1corejs2: typescript.corejs,
@@ -2390,13 +2409,13 @@ exports.tests = [
       {
         name: '__lookupGetter__, ToObject(this)',
         exec: function () {/*
-         __lookupGetter__.call(1, 'key');
-         try {
-         __lookupGetter__.call(null, 'key');
-         } catch(e){
-         return true;
-         }
-         */},
+          __lookupGetter__.call(1, 'key');
+          try {
+            __lookupGetter__.call(null, 'key');
+          } catch (e) {
+            return true;
+          }
+        */},
         res: {
           babel6corejs2: babel.corejs,
           typescript1corejs2: typescript.corejs,
@@ -2422,12 +2441,12 @@ exports.tests = [
       {
         name: '__lookupGetter__, data properties can shadow accessors',
         exec: function () {/*
-         var a = { };
-         var b = Object.create(a);
-         b.foo = 1;
-         a.__defineGetter__("foo", function () {})
-         return b.__lookupGetter__("foo") === void undefined
-         */},
+          var a = {};
+          var b = Object.create(a);
+          b.foo = 1;
+          a.__defineGetter__("foo", function () {});
+          return b.__lookupGetter__("foo") === void undefined;
+        */},
         res: {
           babel6corejs2: babel.corejs,
           typescript1corejs2: typescript.corejs,
@@ -2455,15 +2474,15 @@ exports.tests = [
         name: '__lookupSetter__',
         mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__lookupSetter__',
         exec: function () {/*
-         var obj = {
-         set foo(baz) { return "bar"; },
-         qux: 1
-         };
-         var foo = Object.prototype.__lookupSetter__.call(obj, "foo");
-         return foo() === "bar"
-         && Object.prototype.__lookupSetter__.call(obj, "qux") === void undefined
-         && Object.prototype.__lookupSetter__.call(obj, "baz") === void undefined;
-         */},
+          var obj = {
+            set foo(baz) { return "bar"; },
+            qux: 1
+          };
+          var foo = Object.prototype.__lookupSetter__.call(obj, "foo");
+          return foo() === "bar"
+            && Object.prototype.__lookupSetter__.call(obj, "qux") === void undefined
+            && Object.prototype.__lookupSetter__.call(obj, "baz") === void undefined;
+        */},
         res: {
           babel6corejs2: babel.corejs,
           typescript1corejs2: typescript.corejs,
@@ -2490,15 +2509,15 @@ exports.tests = [
       {
         name: '__lookupSetter__, prototype chain',
         exec: function () {/*
-         var obj = {
-         set foo(baz) { return "bar"; },
-         qux: 1
-         };
-         var foo = Object.prototype.__lookupSetter__.call(Object.create(obj), "foo");
-         return foo() === "bar"
-         && Object.prototype.__lookupSetter__.call(obj, "qux") === void undefined
-         && Object.prototype.__lookupSetter__.call(obj, "baz") === void undefined;
-         */},
+          var obj = {
+            set foo(baz) { return "bar"; },
+            qux: 1
+          };
+          var foo = Object.prototype.__lookupSetter__.call(Object.create(obj), "foo");
+          return foo() === "bar"
+            && Object.prototype.__lookupSetter__.call(obj, "qux") === void undefined
+            && Object.prototype.__lookupSetter__.call(obj, "baz") === void undefined;
+        */},
         res: {
           babel6corejs2: babel.corejs,
           typescript1corejs2: typescript.corejs,
@@ -2526,16 +2545,16 @@ exports.tests = [
       {
         name: '__lookupSetter__, symbols',
         exec: function () {/*
-         var sym = Symbol();
-         var sym2 = Symbol();
-         var obj = {};
-         Object.defineProperty(obj, sym, { set: function(baz) { return "bar"; }});
-         Object.defineProperty(obj, sym2, { value: 1 });
-         var foo = Object.prototype.__lookupSetter__.call(obj, sym);
-         return foo() === "bar"
-         && Object.prototype.__lookupSetter__.call(obj, sym2) === void undefined
-         && Object.prototype.__lookupSetter__.call(obj, Symbol()) === void undefined;
-         */},
+          var sym = Symbol();
+          var sym2 = Symbol();
+          var obj = {};
+          Object.defineProperty(obj, sym, { set: function (baz) { return "bar"; }});
+          Object.defineProperty(obj, sym2, { value: 1 });
+          var foo = Object.prototype.__lookupSetter__.call(obj, sym);
+          return foo() === "bar"
+            && Object.prototype.__lookupSetter__.call(obj, sym2) === void undefined
+            && Object.prototype.__lookupSetter__.call(obj, Symbol()) === void undefined;
+        */},
         res: {
           babel6corejs2: babel.corejs,
           typescript1corejs2: typescript.corejs,
@@ -2562,13 +2581,13 @@ exports.tests = [
       {
         name: '__lookupSetter__, ToObject(this)',
         exec: function () {/*
-         __lookupSetter__.call(1, 'key');
-         try {
-         __lookupSetter__.call(null, 'key');
-         } catch(e){
-         return true;
-         }
-         */},
+          __lookupSetter__.call(1, 'key');
+          try {
+            __lookupSetter__.call(null, 'key');
+          } catch (e) {
+            return true;
+          }
+        */},
         res: {
           babel6corejs2: babel.corejs,
           typescript1corejs2: typescript.corejs,
@@ -2594,12 +2613,12 @@ exports.tests = [
       {
         name: '__lookupSetter__, data properties can shadow accessors',
         exec: function () {/*
-         var a = { };
-         var b = Object.create(a);
-         b.foo = 1;
-         a.__defineSetter__("foo", function () {})
-         return b.__lookupSetter__("foo") === void undefined
-         */},
+          var a = {};
+          var b = Object.create(a);
+          b.foo = 1;
+          a.__defineSetter__("foo", function () {})
+          return b.__lookupSetter__("foo") === void undefined
+        */},
         res: {
           babel6corejs2: babel.corejs,
           typescript1corejs2: typescript.corejs,
@@ -2633,12 +2652,18 @@ exports.tests = [
     subtests: [{
       name: '__defineGetter__',
       exec: function () {/*
-       // Object.prototype.__defineGetter__ -> DefinePropertyOrThrow -> [[DefineOwnProperty]]
-       var def = [];
-       var p = new Proxy({}, { defineProperty: function(o, v, desc) { def.push(v); Object.defineProperty(o, v, desc); return true; }});
-       Object.prototype.__defineGetter__.call(p, "foo", Object);
-       return def + '' === "foo";
-       */},
+        // Object.prototype.__defineGetter__ -> DefinePropertyOrThrow -> [[DefineOwnProperty]]
+        var def = [];
+        var p = new Proxy({}, {
+          defineProperty: function (o, v, desc) {
+            def.push(v);
+            Object.defineProperty(o, v, desc);
+            return true;
+          }
+        });
+        Object.prototype.__defineGetter__.call(p, "foo", Object);
+        return def + '' === "foo";
+      */},
       res: {
         firefox2: false,
         firefox18: true,
@@ -2659,12 +2684,18 @@ exports.tests = [
       {
         name: '__defineSetter__',
         exec: function () {/*
-         // Object.prototype.__defineSetter__ -> DefinePropertyOrThrow -> [[DefineOwnProperty]]
-         var def = [];
-         var p = new Proxy({}, { defineProperty: function(o, v, desc) { def.push(v); Object.defineProperty(o, v, desc); return true; }});
-         Object.prototype.__defineSetter__.call(p, "foo", Object);
-         return def + '' === "foo";
-         */},
+          // Object.prototype.__defineSetter__ -> DefinePropertyOrThrow -> [[DefineOwnProperty]]
+          var def = [];
+          var p = new Proxy({}, {
+            defineProperty: function (o, v, desc) {
+              def.push(v);
+              Object.defineProperty(o, v, desc);
+              return true;
+            }
+          });
+          Object.prototype.__defineSetter__.call(p, "foo", Object);
+          return def + '' === "foo";
+        */},
         res: {
           firefox2: false,
           firefox18: true,
@@ -2685,17 +2716,23 @@ exports.tests = [
       {
         name: '__lookupGetter__',
         exec: function () {/*
-         // Object.prototype.__lookupGetter__ -> [[GetOwnProperty]]
-         // Object.prototype.__lookupGetter__ -> [[GetPrototypeOf]]
-         var gopd = [];
-         var gpo = false;
-         var p = new Proxy({}, {
-         getPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },
-         getOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }
-         });
-         Object.prototype.__lookupGetter__.call(p, "foo");
-         return gopd + '' === "foo" && gpo;
-         */},
+          // Object.prototype.__lookupGetter__ -> [[GetOwnProperty]]
+          // Object.prototype.__lookupGetter__ -> [[GetPrototypeOf]]
+          var gopd = [];
+          var gpo = false;
+          var p = new Proxy({}, {
+            getPrototypeOf: function (o) {
+              gpo = true;
+              return Object.getPrototypeOf(o);
+            },
+            getOwnPropertyDescriptor: function (o, v) {
+              gopd.push(v);
+              return Object.getOwnPropertyDescriptor(o, v);
+            }
+          });
+          Object.prototype.__lookupGetter__.call(p, "foo");
+          return gopd + '' === "foo" && gpo;
+        */},
         res: {
           ie11: false,
           edge14: true,
@@ -2717,17 +2754,23 @@ exports.tests = [
       {
         name: '__lookupSetter__',
         exec: function () {/*
-         // Object.prototype.__lookupSetter__ -> [[GetOwnProperty]]
-         // Object.prototype.__lookupSetter__ -> [[GetPrototypeOf]]
-         var gopd = [];
-         var gpo = false;
-         var p = new Proxy({}, {
-         getPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },
-         getOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }
-         });
-         Object.prototype.__lookupSetter__.call(p, "foo");
-         return gopd + '' === "foo" && gpo;
-         */},
+          // Object.prototype.__lookupSetter__ -> [[GetOwnProperty]]
+          // Object.prototype.__lookupSetter__ -> [[GetPrototypeOf]]
+          var gopd = [];
+          var gpo = false;
+          var p = new Proxy({}, {
+            getPrototypeOf: function (o) {
+              gpo = true;
+              return Object.getPrototypeOf(o);
+            },
+            getOwnPropertyDescriptor: function (o, v) {
+              gopd.push(v);
+              return Object.getOwnPropertyDescriptor(o, v);
+            }
+          });
+          Object.prototype.__lookupSetter__.call(p, "foo");
+          return gopd + '' === "foo" && gpo;
+        */},
         res: {
           ie11: false,
           edge14: true,
@@ -2754,7 +2797,7 @@ exports.tests = [
     significance: 'tiny',
     spec: 'https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys',
     mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys',
-    exec: function() {/*
+    exec: function () {/*
       var p = new Proxy({}, {
         ownKeys() {
           return ["a", "a"];
@@ -2763,7 +2806,7 @@ exports.tests = [
       try {
         Object.keys(p);
       } catch (e) {
-         return e instanceof TypeError
+        return e instanceof TypeError;
       }
       return false;
     */},
@@ -2788,12 +2831,12 @@ exports.tests = [
     category: '2017 misc',
     significance: 'tiny',
     spec: 'https://github.com/tc39/ecma262/pull/525',
-    exec: function() {/*
-     return "ſ".match(/\w/iu) && !"ſ".match(/\W/iu)
-     && "\u212a".match(/\w/iu) && !"\u212a".match(/\W/iu)
-     && "\u212a".match(/.\b/iu) && "ſ".match(/.\b/iu)
-     && !"\u212a".match(/.\B/iu) && !"ſ".match(/.\B/iu);
-     */},
+    exec: function () {/*
+      return "ſ".match(/\w/iu) && !"ſ".match(/\W/iu)
+        && "\u212a".match(/\w/iu) && !"\u212a".match(/\W/iu)
+        && "\u212a".match(/.\b/iu) && "ſ".match(/.\b/iu)
+        && !"\u212a".match(/.\B/iu) && !"ſ".match(/.\B/iu);
+    */},
     res: {
       ie11: false,
       firefox2: false,
@@ -2817,10 +2860,10 @@ exports.tests = [
     mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in#Compatibility_Initializer_expressions_in_strict_mode',
     category: '2017 annex b',
     significance: 'tiny',
-    exec: function(){/*
-     for (var i = 0 in {}) {}
-     return i === 0;
-     */},
+    exec: function () {/*
+      for (var i = 0 in {}) {}
+      return i === 0;
+    */},
     res: {
       tr: true,
       babel7corejs3: true,
@@ -2855,12 +2898,12 @@ exports.tests = [
     significance: 'tiny',
     spec: 'https://github.com/tc39/ecma262/pull/689',
     mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments/caller',
-    exec: function() {/*
-     return (function(){
-       'use strict';
-       return !Object.getOwnPropertyDescriptor(arguments,'caller');
-     })();
-     */},
+    exec: function () {/*
+      return (function () {
+        'use strict';
+        return !Object.getOwnPropertyDescriptor(arguments, 'caller');
+      })();
+    */},
     res: {
       ie11: false,
       edge16: true,
@@ -2889,9 +2932,9 @@ exports.tests = [
       {
         name: 'object rest properties',
         exec: function () {/*
-          var {a, ...rest} = {a: 1, b: 2, c: 3};
+          var { a, ...rest } = { a: 1, b: 2, c: 3 };
           return a === 1 && rest.a === void undefined && rest.b === 2 && rest.c === 3;
-          */},
+        */},
         res: {
           babel6corejs2: true,
           closure: true,
@@ -2925,10 +2968,10 @@ exports.tests = [
       {
         name: 'object spread properties',
         exec: function () {/*
-          var spread = {b: 2, c: 3};
-          var O = {a: 1, ...spread};
+          var spread = { b: 2, c: 3 };
+          var O = { a: 1, ...spread };
           return O !== spread && (O.a + O.b + O.c) === 6;
-          */},
+        */},
         res: {
           babel6corejs2: true,
           closure: true,
@@ -2969,35 +3012,35 @@ exports.tests = [
     subtests: [
       {
         name: 'basic support',
-        exec: function(){/*
-        var p1 = Promise.resolve("foo");
-        var p2 = Promise.reject("bar");
-        var score = 0;
-        function thenFn(result)  {
-          score += (result === "foo");
-          check();
-        }
-        function catchFn(result) {
-          score += (result === "bar");
-          check();
-        }
-        function finallyFn() {
-          score += (arguments.length === 0);
-          check();
-        }
-        p1.then(thenFn);
-        p1.finally(finallyFn);
-        p1.finally(function() {
-          // should return a new Promise
-          score += p1.finally() !== p1;
-          check();
-        });
-        p2.catch(catchFn);
-        p2.finally(finallyFn);
-        function check() {
-          if (score === 5) asyncTestPassed();
-        }
-      */},
+        exec: function () {/*
+          var p1 = Promise.resolve("foo");
+          var p2 = Promise.reject("bar");
+          var score = 0;
+          function thenFn(result) {
+            score += (result === "foo");
+            check();
+          }
+          function catchFn(result) {
+            score += (result === "bar");
+            check();
+          }
+          function finallyFn() {
+            score += (arguments.length === 0);
+            check();
+          }
+          p1.then(thenFn);
+          p1.finally(finallyFn);
+          p1.finally(function () {
+            // should return a new Promise
+            score += p1.finally() !== p1;
+            check();
+          });
+          p2.catch (catchFn);
+          p2.finally(finallyFn);
+          function check() {
+            if (score === 5) asyncTestPassed();
+          }
+        */},
         res: {
           babel6corejs2: babel.corejs,
           closure: false,
@@ -3021,32 +3064,33 @@ exports.tests = [
           hermes0_7_0: false,
           hermes0_12_0: true,
           reactnative0_70_3: true,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          rhino1_7_15: true
         }
       },
       {
         name: 'don\'t change resolution value',
-        exec: function(){/*
-        var score = 0;
-        function thenFn(result)  {
-          score += (result === "foo");
-          check();
-        }
-        function catchFn(result) {
-          score += (result === "bar");
-          check();
-        }
-        function finallyFn() {
-          score++;
-          check();
-          return Promise.resolve("foobar");
-        }
-        Promise.resolve("foo").finally(finallyFn).then(thenFn);
-        Promise.reject("bar").finally(finallyFn).catch(catchFn);
-        function check() {
-          if (score === 4) asyncTestPassed();
-        }
-      */},
+        exec: function () {/*
+          var score = 0;
+          function thenFn(result)  {
+            score += (result === "foo");
+            check();
+          }
+          function catchFn(result) {
+            score += (result === "bar");
+            check();
+          }
+          function finallyFn() {
+            score++;
+            check();
+            return Promise.resolve("foobar");
+          }
+          Promise.resolve("foo").finally(finallyFn).then(thenFn);
+          Promise.reject("bar").finally(finallyFn).catch(catchFn);
+          function check() {
+            if (score === 4) asyncTestPassed();
+          }
+        */},
         res: {
           babel6corejs2: babel.corejs,
           closure: false,
@@ -3070,34 +3114,35 @@ exports.tests = [
           hermes0_7_0: false,
           hermes0_12_0: true,
           reactnative0_70_3: true,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          rhino1_7_15: true
         }
       },
       {
         name: 'change rejection value',
-        exec: function(){/*
-        var score = 0;
-        Promise
-          .reject("foobar")
-          .finally(function() {
-            return Promise.reject("foo");
-          })
-          .catch(function(result) {
-            score += (result === "foo");
-            check();
-            return Promise.reject("foobar");
-          })
-          .finally(function() {
-            throw new Error('bar');
-          })
-          .catch(function(result) {
-            score += (result.message === "bar");
-            check();
-          });
-        function check() {
-          if (score === 2) asyncTestPassed();
-        }
-      */},
+        exec: function () {/*
+          var score = 0;
+          Promise
+            .reject("foobar")
+            .finally(function () {
+              return Promise.reject("foo");
+            })
+            .catch (function (result) {
+              score += (result === "foo");
+              check();
+              return Promise.reject("foobar");
+            })
+            .finally(function () {
+              throw new Error('bar');
+            })
+            .catch (function (result) {
+              score += (result.message === "bar");
+              check();
+            });
+          function check() {
+            if (score === 2) asyncTestPassed();
+          }
+        */},
         res: {
           babel6corejs2: babel.corejs,
           closure: false,
@@ -3121,7 +3166,8 @@ exports.tests = [
           hermes0_7_0: false,
           hermes0_12_0: true,
           reactnative0_70_3: true,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          rhino1_7_15: true
         }
       }
     ]
@@ -3131,16 +3177,16 @@ exports.tests = [
     spec: 'https://github.com/tc39/proposal-template-literal-revision',
     category: '2018 misc',
     significance: 'small',
-    exec: function() {/*
-     function tag(strings, a) {
-     return strings[0] === void 0 &&
-     strings.raw[0] === "\\01\\1\\xg\\xAg\\u0\\u0g\\u00g\\u000g\\u{g\\u{0\\u{110000}" &&
-     strings[1] === "\0" &&
-     strings.raw[1] === "\\0" &&
-     a === 0;
-     }
-     return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
-     */},
+    exec: function () {/*
+      function tag(strings, a) {
+        return strings[0] === void undefined
+          && strings.raw[0] === "\\01\\1\\xg\\xAg\\u0\\u0g\\u00g\\u000g\\u{g\\u{0\\u{110000}"
+          && strings[1] === "\0"
+          && strings.raw[1] === "\\0"
+          && a === 0;
+      }
+      return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
+    */},
     res: {
       babel7corejs3: true,
       closure: false,
@@ -3169,7 +3215,7 @@ exports.tests = [
     mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll',
     category: '2018 features',
     significance: 'small',
-    exec: function(){/*
+    exec: function () {/*
     const regex = /foo.bar/s;
     return regex.test('foo\nbar');
   */},
@@ -3207,7 +3253,8 @@ exports.tests = [
       graalvm19: true,
       hermes0_7_0: true,
       reactnative0_70_3: true,
-      rhino1_7_13: false
+      rhino1_7_13: false,
+      rhino1_7_15: true
     }
   },
   {
@@ -3216,7 +3263,7 @@ exports.tests = [
     mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges',
     category: '2018 features',
     significance: 'small',
-    exec: function(){/*
+    exec: function () {/*
       var result = /(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})/.exec('2016-03-11');
       return result.groups.year === '2016'
         && result.groups.month === '03'
@@ -3251,7 +3298,7 @@ exports.tests = [
     mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Assertions',
     category: '2018 features',
     significance: 'small',
-    exec: function(){/*
+    exec: function () {/*
     return /(?<=a)b/.test('ab') && /(?<!a)b/.test('cb') &&
            !/(?<=a)b/.test('b');
   */},
@@ -3265,6 +3312,7 @@ exports.tests = [
       chrome50: chrome.harmony,
       chrome62: true,
       safari13_1: false,
+      safari16_4: true,
       duktape2_0: false,
       jerryscript2_3_0: false,
       graalvm19: true,
@@ -3280,28 +3328,200 @@ exports.tests = [
     significance: 'small',
     spec: 'https://github.com/tc39/proposal-regexp-unicode-property-escapes',
     mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes',
-    exec: function () {/*
-    const regexGreekSymbol = /\p{Script=Greek}/u;
-    return regexGreekSymbol.test('π');
-  */},
-    res: {
-      babel6corejs2: true,
-      ie11: false,
-      firefox2: false,
-      firefox77: false,
-      firefox78: true,
-      opera10_50: false,
-      chrome59: chrome.harmony,
-      chrome64: true,
-      safari11_1: true,
-      safaritp: true,
-      duktape2_0: false,
-      jerryscript2_3_0: false,
-      graalvm19: true,
-      hermes0_7_0: false,
-      reactnative0_70_3: true,
-      rhino1_7_13: false
-    }
+    subtests: [
+      {
+        name: 'basic',
+        exec: function () {/*
+        const regexGreekSymbol = /\p{Script=Greek}/u;
+        return regexGreekSymbol.test('π');
+      */},
+        res: {
+          babel6corejs2: true,
+          ie11: false,
+          firefox2: false,
+          firefox77: false,
+          firefox78: true,
+          opera10_50: false,
+          chrome59: chrome.harmony,
+          chrome64: true,
+          safari11_1: true,
+          safaritp: true,
+          duktape2_0: false,
+          jerryscript2_3_0: false,
+          graalvm19: true,
+          hermes0_7_0: false,
+          reactnative0_70_3: true,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: 'Unicode 11',
+        // 2018	June 5
+        exec: function () {/*
+        return /\p{Extended_Pictographic}/u.test("\xA9") && /\p{Emoji}/u.test("🥰");
+      */},
+        res: {
+          chrome67: false,
+          chrome68: true,
+          firefox77: false,
+          firefox78: true,
+          safari14: false,
+          safari14_1: true,
+          node10_9: false,
+          node11_0: true,
+          duktape2_0: false,
+          ie11: false,
+          jerryscript2_3_0: false,
+          hermes0_7_0: false,
+          rhino1_7_13: false,
+        }
+      },
+      {
+        name: 'Unicode 12',
+        // 2019	March 5
+        exec: function () {/*
+        return /\p{Script=Elymaic}/u.test("\u{10fe0}") && /\p{Emoji}/u.test("🥱");
+      */},
+        res: {
+          chrome74: false,
+          chrome75: true,
+          firefox77: false,
+          firefox78: true,
+          safari14: false,
+          safari14_1: true,
+          node12_0: false,
+          node12_5: true,
+          duktape2_0: false,
+          ie11: false,
+          jerryscript2_3_0: false,
+          hermes0_7_0: false,
+          rhino1_7_13: false,
+        }
+      },
+      {
+        name: 'Unicode 12.1',
+        // 2019	May 7
+        exec: function () {/*
+        return /\p{Other_Symbol}/u.test("\u32FF");
+      */},
+        res: {
+          chrome74: false,
+          chrome75: true,
+          firefox77: false,
+          firefox78: true,
+          safari14: false,
+          safari14_1: true,
+          node12_0: false,
+          node12_5: true,
+          duktape2_0: false,
+          ie11: false,
+          jerryscript2_3_0: false,
+          hermes0_7_0: false,
+          rhino1_7_13: false,
+        }
+      },
+      {
+        name: 'Unicode 13',
+        // 2020	March 10
+        exec: function () {/*
+        return /\p{Script=Chorasmian}/u.test("\u{10fb0}") && /\p{Emoji}/u.test("🥲");
+      */},
+        res: {
+          chrome83: false,
+          chrome84: true,
+          firefox77: false,
+          firefox78: true,
+          safari14: false,
+          safari14_1: true,
+          node13_2: false,
+          node14_0: true,
+          duktape2_0: false,
+          ie11: false,
+          jerryscript2_3_0: false,
+          hermes0_7_0: false,
+          rhino1_7_13: false,
+        }
+      },
+      {
+        name: 'Unicode 14',
+        // 2021	September 14
+        exec: function () {/*
+        return /\p{Script=Vithkuqi}/u.test("\u{10570}") && /\p{Emoji}/u.test("🫠");
+      */},
+        res: {
+          ie11: false,
+          chrome97: false,
+          chrome98: true,
+          firefox95: false,
+          firefox96: true,
+          safari15_3: false,
+          safari15_4: true,
+          node16_11: false,
+          node17_0: false,
+          node17_2: true,
+          duktape2_0: false,
+          jerryscript2_3_0: false,
+          hermes0_7_0: false,
+          rhino1_7_13: false,
+        }
+      },
+      {
+        name: 'Unicode 15',
+        // 2022	September 13
+        exec: function () {/*
+        return /\p{Script=Kawi}/u.test("\u{11f00}") && /\p{Emoji}/u.test("🫨");
+      */},
+        res: {
+          ie11: false,
+          chrome109: false,
+          chrome110: true,
+          firefox109: false,
+          firefox110: true,
+          safari11_1: false,
+          safari16_6: false,
+          safari17: true,
+          safaritp: true,
+          node0_10: false,
+          node16_11: false,
+          node18_3: false,
+          node19_0: false,
+          node19_2: true,
+          duktape2_0: false,
+          jerryscript2_3_0: false,
+          hermes0_7_0: false,
+          rhino1_7_13: false,
+        }
+      },
+      {
+        name: 'Unicode 15.1',
+        // 2023 September 12
+        exec: function () {/*
+        return /\p{Unified_Ideograph}/u.test("\u{2ebf0}");
+      */},
+        res: {
+          ie11: false,
+          chrome117: false,
+          chrome118: false,
+          chrome124: false,
+          chrome125: true,
+          node20_0: false,
+          node21_0: false,
+          node22_0: true,
+          firefox2: false,
+          firefox115: false,
+          firefox117: false,
+          firefox118: false,
+          safari11_1: false,
+          safaritp: false,
+          safari17: false,
+          safari18: true,
+          duktape2_0: false,
+          jerryscript2_3_0: false,
+          hermes0_7_0: false,
+          rhino1_7_13: false,
+        }
+      }
+    ]
   },
   {
     name: 'Asynchronous Iterators',
@@ -3311,13 +3531,13 @@ exports.tests = [
     subtests: [
       {
         name: 'async generators',
-        exec: function(){/*
-          async function*generator(){
+        exec: function () {/*
+          async function*generator() {
             yield 42;
           }
 
           var iterator = generator();
-          iterator.next().then(function(step){
+          iterator.next().then(function (step) {
             if(iterator[Symbol.asyncIterator]() === iterator && step.done === false && step.value === 42)asyncTestPassed();
           });
         */},
@@ -3347,13 +3567,13 @@ exports.tests = [
       {
         name: 'for-await-of loops',
         mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of',
-        exec: function(){/*
+        exec: function () {/*
           var asyncIterable = {};
-          asyncIterable[Symbol.asyncIterator] = function(){
+          asyncIterable[Symbol.asyncIterator] = function () {
             var i = 0;
             return {
-              next: function(){
-                switch(++i){
+              next: function () {
+                switch(++i) {
                   case 1: return Promise.resolve({done: false, value: 'a'});
                   case 2: return Promise.resolve({done: false, value: 'b'});
                 } return Promise.resolve({done: true});
@@ -3361,7 +3581,7 @@ exports.tests = [
             };
           };
 
-          (async function(){
+          (async function () {
             var result = '';
             for await(var value of asyncIterable)result += value;
             if(result === 'ab')asyncTestPassed();
@@ -3400,7 +3620,7 @@ exports.tests = [
     subtests: [
       {
         name: 'basic',
-        exec: function(){/*
+        exec: function () {/*
           try {
             throw new Error();
           }
@@ -3430,13 +3650,14 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: true,
           reactnative0_70_3: true,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          rhino1_7_15: true
         }
       },
       {
         name: 'await',
-        exec: function(){/*
-          (async function (){
+        exec: function () {/*
+          (async function () {
             try {
               await Promise.reject();
             }
@@ -3472,7 +3693,7 @@ exports.tests = [
       },
       {
         name: 'yield',
-        exec: function(){/*
+        exec: function () {/*
           function *foo() {
             try {
               yield;
@@ -3506,7 +3727,8 @@ exports.tests = [
           graalvm20: true,
           hermes0_7_0: true,
           reactnative0_70_3: true,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          rhino1_7_15: true
         }
       }
     ]
@@ -3520,7 +3742,7 @@ exports.tests = [
     subtests: [
       {
         name: 'basic',
-        exec: function(){/*
+        exec: function () {/*
           return Symbol('foo').description === 'foo';
         */},
         res : {
@@ -3552,7 +3774,7 @@ exports.tests = [
       },
       {
         name: 'empty description',
-        exec: function(){/*
+        exec: function () {/*
           return Symbol('').description === '';
         */},
         res : {
@@ -3584,7 +3806,7 @@ exports.tests = [
       },
       {
         name: 'undefined description',
-        exec: function(){/*
+        exec: function () {/*
           return Symbol.prototype.hasOwnProperty('description')
             && Symbol().description === void undefined;
         */},
@@ -3623,8 +3845,8 @@ exports.tests = [
     mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/toString',
     subtests: [{
       name: 'functions created with the Function constructor',
-      exec: function(){/*
-        var fn = Function('a', ' /\x2A a \x2A/ b, c /\x2A b \x2A/ //', '/\x2A c \x2A/ ; /\x2A d \x2A/ //');
+      exec: function () {/*
+        var fn = Function ('a', ' /\x2A a \x2A/ b, c /\x2A b \x2A/ //', '/\x2A c \x2A/ ; /\x2A d \x2A/ //');
         var str = 'function anonymous(a, /\x2A a \x2A/ b, c /\x2A b \x2A/ //\n) {\n/\x2A c \x2A/ ; /\x2A d \x2A/ //\n}';
         return fn + '' === str;
     */},
@@ -3640,11 +3862,12 @@ exports.tests = [
         graalvm19: true,
         hermes0_7_0: false,
         reactnative0_70_3: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        safari18: true,
       }
     }, {
       name: 'arrows',
-      exec: function(){/*
+      exec: function () {/*
         var str = 'a => b';
         return eval('(' + str + ')') + '' === str;
     */},
@@ -3669,7 +3892,7 @@ exports.tests = [
       }
     }, {
       name: '[native code]',
-      exec: function(){/*
+      exec: function () {/*
         const NATIVE_EVAL_RE = /\bfunction\b[\s\S]*\beval\b[\s\S]*\([\s\S]*\)[\s\S]*\{[\s\S]*\[[\s\S]*\bnative\b[\s\S]+\bcode\b[\s\S]*\][\s\S]*\}/;
         return NATIVE_EVAL_RE.test(eval + '');
     */},
@@ -3694,7 +3917,7 @@ exports.tests = [
       }
     }, {
       name: 'class expression with implicit constructor',
-      exec: function(){/*
+      exec: function () {/*
         var str = 'class A {}';
         return eval('(' + str + ')') + '' === str;
     */},
@@ -3716,8 +3939,8 @@ exports.tests = [
       }
     }, {
       name: 'class expression with explicit constructor',
-      exec: function(){/*
-        var str = 'class /\x2A a \x2A/ A /\x2A b \x2A/ extends /\x2A c \x2A/ function B(){} /\x2A d \x2A/ { /\x2A e \x2A/ constructor /\x2A f \x2A/ ( /\x2A g \x2A/ ) /\x2A h \x2A/ { /\x2A i \x2A/ ; /\x2A j \x2A/ } /\x2A k \x2A/ m /\x2A l \x2A/ ( /\x2A m \x2A/ ) /\x2A n \x2A/ { /\x2A o \x2A/ } /\x2A p \x2A/ }';
+      exec: function () {/*
+        var str = 'class /\x2A a \x2A/ A /\x2A b \x2A/ extends /\x2A c \x2A/ function B() {} /\x2A d \x2A/ { /\x2A e \x2A/ constructor /\x2A f \x2A/ ( /\x2A g \x2A/ ) /\x2A h \x2A/ { /\x2A i \x2A/ ; /\x2A j \x2A/ } /\x2A k \x2A/ m /\x2A l \x2A/ ( /\x2A m \x2A/ ) /\x2A n \x2A/ { /\x2A o \x2A/ } /\x2A p \x2A/ }';
         return eval('(/\x2A before \x2A/' + str + '/\x2A after \x2A/)') + '' === str;
     */},
       res: {
@@ -3738,7 +3961,7 @@ exports.tests = [
       }
     }, {
       name: 'unicode escape sequences in identifiers',
-      exec: function(){/*
+      exec: function () {/*
         var str = 'function \\u0061(\\u{62}, \\u0063) { \\u0062 = \\u{00063}; return b; }';
         return eval('(/\x2A before \x2A/' + str + '/\x2A after \x2A/)') + '' === str;
     */},
@@ -3749,6 +3972,7 @@ exports.tests = [
         opera10_50: false,
         chrome59: chrome.harmony,
         chrome66: true,
+        safari17: true,
         duktape2_0: false,
         jerryscript2_3_0: false,
         graalvm19: true,
@@ -3758,7 +3982,7 @@ exports.tests = [
       }
     }, {
       name: 'methods and computed property names',
-      exec: function(){/*
+      exec: function () {/*
         var str = '[ /\x2A a \x2A/ "f" /\x2A b \x2A/ ] /\x2A c \x2A/ ( /\x2A d \x2A/ ) /\x2A e \x2A/ { /\x2A f \x2A/ }';
         return eval('({ /\x2A before \x2A/' + str + '/\x2A after \x2A/ }.f)') + '' === str;
     */},
@@ -3769,6 +3993,7 @@ exports.tests = [
         opera10_50: false,
         chrome59: chrome.harmony,
         chrome66: true,
+        safari17: true,
         duktape2_0: false,
         nashorn9: true,
         nashorn10: true,
@@ -3788,7 +4013,7 @@ exports.tests = [
     subtests: [
       {
         name: 'LINE SEPARATOR can appear in string literals',
-        exec: function(){/*
+        exec: function () {/*
           return eval("'\u2028'") === "\u2028";
         */},
         res : {
@@ -3815,7 +4040,7 @@ exports.tests = [
       },
       {
         name: 'PARAGRAPH SEPARATOR can appear in string literals',
-        exec: function(){/*
+        exec: function () {/*
           return eval("'\u2029'") === "\u2029";
         */},
         res : {
@@ -3923,7 +4148,7 @@ exports.tests = [
       {
         name: 'String.prototype.trimLeft',
         mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimLeft',
-        exec: function(){/*
+        exec: function () {/*
         return ' \t \n abc   \t\n'.trimLeft() === 'abc   \t\n';
       */},
         res: {
@@ -3966,7 +4191,7 @@ exports.tests = [
       {
         name: 'String.prototype.trimRight',
         mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/TrimRight',
-        exec: function(){/*
+        exec: function () {/*
         return ' \t \n abc   \t\n'.trimRight() === ' \t \n abc';
       */},
         res: {
@@ -4009,7 +4234,7 @@ exports.tests = [
       {
         name: 'String.prototype.trimStart',
         mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimStart',
-        exec: function(){/*
+        exec: function () {/*
         return ' \t \n abc   \t\n'.trimStart() === 'abc   \t\n';
       */},
         res: {
@@ -4042,7 +4267,7 @@ exports.tests = [
       {
         name: 'String.prototype.trimEnd',
         mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd',
-        exec: function(){/*
+        exec: function () {/*
         return ' \t \n abc   \t\n'.trimEnd() === ' \t \n abc';
       */},
         res: {
@@ -4089,7 +4314,7 @@ exports.tests = [
       {
         name: 'Array.prototype.flat',
         mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat',
-        exec: function(){/*
+        exec: function () {/*
         return [1, [2, 3], [4, [5, 6]]].flat().join('') === '12345,6';
       */},
         res: {
@@ -4118,13 +4343,14 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: true,
           reactnative0_70_3: true,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          rhino1_7_15: true
         }
       },
       {
         name: 'Array.prototype.flatMap',
         mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap',
-        exec: function(){/*
+        exec: function () {/*
         return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
           return [it.a, it.b];
         }).join('') === '1234';
@@ -4148,12 +4374,13 @@ exports.tests = [
           graalvm19: true,
           hermes0_7_0: true,
           reactnative0_70_3: true,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          rhino1_7_15: true
         }
       },
       {
         name: 'flat and flatMap in Array.prototype[@@unscopables]',
-        exec: function(){/*
+        exec: function () {/*
         return Array.prototype[Symbol.unscopables].flat
           && Array.prototype[Symbol.unscopables].flatMap;
       */},
@@ -4194,11 +4421,11 @@ exports.tests = [
     subtests: [
       {
         name: 'basic functionality',
-        exec: function(){/*
+        exec: function () {/*
           var iterator = '11a2bb'.matchAll(/(\d)(\D)/g);
           if(iterator[Symbol.iterator]() !== iterator)return false;
           var a = '', b = '', c = '', step;
-          while(!(step = iterator.next()).done){
+          while(!(step = iterator.next()).done) {
             a += step.value[0];
             b += step.value[1];
             c += step.value[2];
@@ -4237,7 +4464,7 @@ exports.tests = [
       },
       {
         name: 'throws on non-global regex',
-        exec: function(){/*
+        exec: function () {/*
           if (typeof String.prototype.matchAll !== 'function') return false;
           try {
             '11a2bb'.matchAll(/(\d)(\D)/);
@@ -4551,8 +4778,8 @@ exports.tests = [
     mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis',
     subtests: [{
       name: '"globalThis" global property is global object',
-      exec: function(){/*
-      var actualGlobal = Function('return this')();
+      exec: function () {/*
+      var actualGlobal = Function ('return this')();
       actualGlobal.__system_global_test__ = 42;
       return typeof globalThis === 'object' && globalThis && globalThis === actualGlobal && !globalThis.lacksGlobalThis && globalThis.__system_global_test__ === 42;
     */},
@@ -4595,8 +4822,8 @@ exports.tests = [
       }
     }, {
       name: '"globalThis" global property has correct property descriptor',
-      exec: function(){/*
-      var actualGlobal = Function('return this')();
+      exec: function () {/*
+      var actualGlobal = Function ('return this')();
       if (typeof globalThis !== 'object') { return false; }
       if (!('globalThis' in actualGlobal)) { return false; }
       if (Object.prototype.propertyIsEnumerable.call(actualGlobal, 'globalThis')) { return false; }
@@ -4652,7 +4879,7 @@ exports.tests = [
     subtests: [
       {
         name: 'optional property access',
-        exec: function(){/*
+        exec: function () {/*
           var foo = { baz: 42 };
           var bar = null;
           return foo?.baz === 42 && bar?.baz === void undefined;
@@ -4684,7 +4911,7 @@ exports.tests = [
       },
       {
         name: 'optional bracket access',
-        exec: function(){/*
+        exec: function () {/*
           var foo = { baz: 42 };
           var bar = null;
           return foo?.['baz'] === 42 && bar?.['baz'] === void undefined;
@@ -4716,7 +4943,7 @@ exports.tests = [
       },
       {
         name: 'optional method call',
-        exec: function(){/*
+        exec: function () {/*
           var foo = { baz: function () { return this.value; }, value: 42 };
           var bar = null;
           return foo?.baz() === 42 && bar?.baz() === void undefined;
@@ -4748,7 +4975,7 @@ exports.tests = [
       },
       {
         name: 'optional function call',
-        exec: function(){/*
+        exec: function () {/*
           var foo = { baz: function () { return 42; } };
           var bar = {};
           function baz() { return 42; };
@@ -4782,7 +5009,7 @@ exports.tests = [
       },
       {
         name: 'spread parameters after optional chaining',
-        exec: function(){/*
+        exec: function () {/*
           var fn = null;
           var n = null;
           var o = {};
@@ -4821,7 +5048,7 @@ exports.tests = [
     mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator',
     category: '2020 features',
     significance: 'small',
-    exec: function(){/*
+    exec: function () {/*
       return (null ?? 42) === 42 &&
         (undefined ?? 42) === 42 &&
         (false ?? 42) === false &&
@@ -4891,7 +5118,8 @@ exports.tests = [
       ios13_4: true,
       hermes0_7_0: true,
       reactnative0_70_3: true,
-      rhino1_7_13: false
+      rhino1_7_13: false,
+      rhino1_7_15: true
     }
   },
   {
@@ -4945,7 +5173,7 @@ exports.tests = [
             Promise.reject(1),
             Promise.reject(2),
             Promise.reject(3)
-          ]).catch(error => {
+          ]).catch (error => {
             if (error instanceof AggregateError && error.errors.length === 3) asyncTestPassed();
           });
         */},
@@ -4987,7 +5215,7 @@ exports.tests = [
       {
         name: 'WeakRef minimal support',
         spec: 'https://github.com/tc39/proposal-weakrefs#weak-references',
-        exec: function(){/*
+        exec: function () {/*
           var O = {};
           var weakref = new WeakRef(O);
           return weakref.deref() === O;
@@ -5021,8 +5249,8 @@ exports.tests = [
       {
         name: 'FinalizationRegistry minimal support',
         spec: 'https://github.com/tc39/proposal-weakrefs#finalizers',
-        exec: function(){/*
-          var fr = new FinalizationRegistry(function() {});
+        exec: function () {/*
+          var fr = new FinalizationRegistry(function () {});
           return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
         */},
         res : {
@@ -5362,7 +5590,7 @@ exports.tests = [
     spec: 'https://github.com/tc39/proposal-numeric-separator',
     category: '2021 features',
     significance: 'small',
-    exec: function(){/*
+    exec: function () {/*
       return 1_000_000.000_001 === 1000000.000001 &&
         0b1010_0001_1000_0101 === 0b1010000110000101;
     */},
@@ -5437,10 +5665,10 @@ exports.tests = [
         exec: function () {/*
           class C {
             #x;
-            constructor(x){
+            constructor(x) {
               this.#x = x;
             }
-            x(){
+            x() {
               return this.#x;
             }
           }
@@ -5471,7 +5699,7 @@ exports.tests = [
         exec: function () {/*
           class C {
             #x = 42;
-            x(){
+            x() {
               return this.#x;
             }
           }
@@ -5502,11 +5730,11 @@ exports.tests = [
         exec: function () {/*
           class C {
             #x = 42;
-            x(o = this){
+            x(o = this) {
               return o?.#x;
             }
           }
-          return new C().x() === 42 && new C().x(null) === void 0;
+          return new C().x() === 42 && new C().x(null) === void undefined;
         */},
         res: {
           babel7corejs2: true,
@@ -5537,11 +5765,11 @@ exports.tests = [
         exec: function () {/*
           class C {
             #x = 42;
-            x(o = {p: this}){
+            x(o = { p: this }) {
               return o?.p.#x;
             }
           }
-          return new C().x() === 42 && new C().x(null) === void 0;
+          return new C().x() === 42 && new C().x(null) === void undefined;
         */},
         res: {
           babel7corejs2: true,
@@ -5594,6 +5822,29 @@ exports.tests = [
           reactnative0_70_3: true,
           rhino1_7_13: false
         }
+      },
+      {
+        name: 'resolving identifier in parent scope',
+        exec: function () {/*
+          {
+            let a = ["hello world"];
+            class MyClass {
+              // The parenthesis below are required to trigger https://bugs.webkit.org/show_bug.cgi?id=236843
+              c = a[(0)];
+            }
+            return new MyClass().c === a[0];
+          }
+        */},
+        res: {
+          firefox122: true,
+          chrome74: true,
+          chrome124: true,
+          firefox69: true,
+          safari15: false,
+          safari16: true,
+          safari17: true,
+          safaritp: true,
+        }
       }
     ]
   },
@@ -5639,14 +5890,20 @@ exports.tests = [
           return (class X { static name = "name"; }).name === 'name';
         */},
         res: {
+          ie11: false,
+          edge18: false,
           chrome73: true,
           chrome90: true,
           chrome94: true,
           chrome96: true,
           chrome97: false,
           chrome98: true,
+          firefox74: false,
+          firefox75: true,
+          firefox91: true,
           firefox95: true,
           firefox96: true,
+          opera10_50: false,
           node11_0: false,
           node12_0: true,
           node12_5: true,
@@ -5666,7 +5923,8 @@ exports.tests = [
           graalvm21_3_3: false,
           graalvm22_2: true,
           hermes0_7_0: false,
-          reactnative0_70_3: true
+          reactnative0_70_3: true,
+          rhino1_7_15: false
         }
       },
       {
@@ -5675,7 +5933,7 @@ exports.tests = [
         exec: function () {/*
           class C {
             static #x = 42;
-            x(){
+            x() {
               return C.#x;
             }
           }
@@ -5929,7 +6187,8 @@ exports.tests = [
     subtests: [
       {
         name: 'Array.prototype.at()',
-        exec: function() {/*
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at',
+        exec: function () {/*
         var arr = [1, 2, 3];
         return arr.at(0) === 1
           && arr.at(-3) === 1
@@ -5969,12 +6228,14 @@ exports.tests = [
           graalvm22_2: true,
           hermes0_7_0: false,
           reactnative0_70_3: false,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          rhino1_7_15: true
         }
       },
       {
         name: 'String.prototype.at()',
-        exec: function() {/*
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/at',
+        exec: function () {/*
         var str = 'abc';
         return str.at(0) === 'a'
           && str.at(-3) === 'a'
@@ -6012,12 +6273,13 @@ exports.tests = [
           graalvm22_2: true,
           hermes0_7_0: false,
           reactnative0_70_3: false,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          rhino1_7_15: true
         }
       },
       {
         name: '%TypedArray%.prototype.at()',
-        exec: function() {/*
+        exec: function () {/*
          return [
            'Int8Array',
            'Uint8Array',
@@ -6071,7 +6333,8 @@ exports.tests = [
           graalvm22_2: true,
           hermes0_7_0: false,
           reactnative0_70_3: false,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          rhino1_7_15: true
         }
       }
     ]
@@ -6111,7 +6374,8 @@ exports.tests = [
           hermes0_7_0: false,
           hermes0_12_0: true,
           reactnative0_70_3: true,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          rhino1_7_15: true
         }
       },
       {
@@ -6148,7 +6412,8 @@ exports.tests = [
           hermes0_7_0: false,
           hermes0_12_0: true,
           reactnative0_70_3: true,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          rhino1_7_15: true
         }
       }
     ]
@@ -6158,6 +6423,7 @@ exports.tests = [
     category: '2022 features',
     significance: 'small',
     spec: 'https://github.com/tc39/proposal-class-static-block',
+    mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks',
     exec: function () {/*
     let ok = false;
     class A {
@@ -6188,7 +6454,7 @@ exports.tests = [
       firefox93: true,
       ie11: false,
       opera10_50: false,
-      safari12: false,
+      safari16_4: true,
       duktape2_0: false,
       graalvm21_3_3: graalvm.esStagingFlag,
       graalvm22_2: true,
@@ -6624,7 +6890,8 @@ exports.tests = [
           graalvm21_3_3: graalvm.esStagingFlag,
           graalvm22_2: true,
           hermes0_7_0: false,
-          reactnative0_70_3: false
+          reactnative0_70_3: false,
+          rhino1_7_15: false
         }
       },
       {
@@ -6639,7 +6906,7 @@ exports.tests = [
           if ('unicode' in RegExp.prototype) expected.push('unicode');
           if ('sticky' in RegExp.prototype) expected.push('sticky');
           var actual = [];
-          var p = new Proxy({}, { get: function(o, k) { actual.push(k); return o[k]; }});
+          var p = new Proxy({}, { get: function (o, k) { actual.push(k); return o[k]; }});
           Object.getOwnPropertyDescriptor(RegExp.prototype, 'flags').get.call(p);
           if (expected.length !== actual.length) return false;
           for (var i = 0; i < expected.length; i++) {
@@ -6652,12 +6919,14 @@ exports.tests = [
           firefox68: false,
           firefox78: false,
           firefox91: true,
+          firefox116: false,
           safari15: true,
           chrome90: false,
           graalvm21_3_3: graalvm.esStagingFlag,
           graalvm22_2: true,
           hermes0_7_0: false,
-          reactnative0_70_3: false
+          reactnative0_70_3: false,
+          rhino1_7_15: false
         }
       }
     ]
@@ -6670,6 +6939,7 @@ exports.tests = [
     subtests: [
       {
         name: "Array.prototype.findLast",
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findLast',
         exec: function () {/*
           var arr = [{ x: 1 }, { x: 2 }, { x: 1 }, { x: 2 }];
           return arr.findLast(function (o) { return o.x === 1; }) === arr[2];
@@ -6707,6 +6977,7 @@ exports.tests = [
       },
       {
         name: "Array.prototype.findLastIndex",
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findLastIndex',
         exec: function () {/*
           var arr = [{ x: 1 }, { x: 2 }, { x: 1 }, { x: 2 }];
           return arr.findLastIndex(function (o) { return o.x === 1; }) === 2;
@@ -6746,7 +7017,7 @@ exports.tests = [
     significance: 'tiny',
     spec: 'https://github.com/tc39/proposal-hashbang/',
     mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Hashbang_comments',
-    exec: function() {/*
+    exec: function () {/*
       try {
         return !eval('#!/wash/your/hands');
       } catch (e) {
@@ -6772,19 +7043,1298 @@ exports.tests = [
       closure: false,
       hermes0_7_0: true,
       reactnative0_70_3: true,
-      rhino1_7_13: false
+      rhino1_7_13: false,
+      rhino1_7_15: true
     }
   },
+  {
+    name: 'Change Array by copy',
+    category: '2023 features',
+    significance: 'small',
+    spec: 'https://github.com/tc39/proposal-change-array-by-copy',
+    subtests: [
+      {
+        name: "Array.prototype.toReversed()",
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toReversed',
+        exec: function () {/*
+          var arr = [1, 2, 3];
+          return arr.toReversed()[0] === 3 && arr[0] === 1;
+        */},
+        res: {
+          babel7corejs3: babel.corejs,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          chrome94: false,
+          chrome109: false,
+          chrome110: true,
+          firefox45: false,
+          firefox95: {val: "flagged", note_id: "fx-change-array-by-copy", note_html: 'The feature has to be enabled via --enable-change-array-by-copy flag'},
+          firefox115: true,
+          safari15_5: false,
+          safari16: true,
+        }
+      },
+      {
+        name: "Array.prototype.toSorted()",
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSorted',
+        exec: function () {/*
+          var arr = ['C', 'A', 'B'];
+          return arr.toSorted()[0] === 'A' && arr[0] === 'C';
+        */},
+        res: {
+          babel7corejs3: babel.corejs,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          chrome94: false,
+          chrome109: false,
+          chrome110: true,
+          firefox45: false,
+          firefox95: {val: "flagged", note_id: "fx-change-array-by-copy"},
+          firefox115: true,
+          safari15_5: false,
+          safari16: true,
+        }
+      },
+      {
+        name: "Array.prototype.toSpliced()",
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSpliced',
+        exec: function () {/*
+          var arr = ['A', 'C'];
+          return arr.toSpliced(1, 0, 'B')[1] === 'B' && arr[1] === 'C';
+        */},
+        res: {
+          babel7corejs3: babel.corejs,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          chrome94: false,
+          chrome109: false,
+          chrome110: true,
+          firefox45: false,
+          firefox95: {val: "flagged", note_id: "fx-change-array-by-copy"},
+          firefox115: true,
+          safari15_5: false,
+          safari16: true,
+        }
+      },
+      {
+        name: "Array.prototype.with()",
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/with',
+        exec: function () {/*
+          var arr = ['A', 'X', 'C'];
+          return arr.with(1, 'B')[1] === 'B' && arr[1] === 'X';
+        */},
+        res: {
+          babel7corejs3: babel.corejs,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          chrome94: false,
+          chrome109: false,
+          chrome110: true,
+          firefox45: false,
+          firefox95: {val: "flagged", note_id: "fx-change-array-by-copy"},
+          firefox115: true,
+          safari15_5: false,
+          safari16: true,
+        }
+      },
+      {
+        name: "TypedArray.prototype.toReversed()",
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toReversed',
+        exec: function () {/*
+          var arr = new Uint8Array([1, 2, 3]);
+          return arr.toReversed()[0] == 3 && arr[0] == 1;
+        */},
+        res: {
+          ie11: false,
+          chrome94: false,
+          chrome109: false,
+          chrome110: true,
+          firefox45: false,
+          firefox95: {val: "flagged", note_id: "fx-change-array-by-copy"},
+          firefox115: true,
+          safari15_5: false,
+          safari16: true,
+        }
+      },
+      {
+        name: "TypedArray.prototype.toSorted()",
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toSorted',
+        exec: function () {/*
+          var arr = new Uint8Array([3, 1, 2]);
+          return arr.toSorted()[0] == 1 && arr[0] == 3;
+        */},
+        res: {
+          ie11: false,
+          chrome94: false,
+          chrome109: false,
+          chrome110: true,
+          firefox45: false,
+          firefox95: {val: "flagged", note_id: "fx-change-array-by-copy"},
+          firefox115: true,
+          safari15_5: false,
+          safari16: true,
+        }
+      },
+      {
+        name: "TypedArray.prototype.with()",
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/with',
+        exec: function () {/*
+          var arr = new Uint8Array([1, 0, 2]);
+          return arr.with(1, 2)[1] == 2 && arr[1] == 0;
+        */},
+        res: {
+          ie11: false,
+          chrome94: false,
+          chrome109: false,
+          chrome110: true,
+          firefox45: false,
+          firefox95: {val: "flagged", note_id: "fx-change-array-by-copy"},
+          firefox115: true,
+          safari15_5: false,
+          safari16: true,
+        }
+      },
+    ]
+  },
+  {
+    name: 'RegExp `v` flag',
+    category: '2024 features',
+    significance: 'small',
+    spec: 'https://github.com/tc39/proposal-regexp-v-flag',
+    subtests: [
+      {
+        name: 'set notations',
+        exec: function () {/*
+          return /[\p{ASCII}&&\p{Decimal_Number}]/v.test("0")
+          && /[\p{Any}--[\x01-\u{10ffff}]]/v.test("\0")
+        */},
+        res: {
+          chrome110: false,
+          chrome111: chrome.harmony,
+          chrome112: true,
+          firefox91: false,
+          firefox102: false,
+          firefox115: false,
+          firefox116: true,
+          ie11: false,
+          safari16_6: false,
+          safari17: true,
+          safaritp: true,
+          rhino1_7_15: false,
+        }
+      },
+      {
+        name: 'properties of Strings',
+        exec: function () {/*
+          return /^\p{Emoji_Keycap_Sequence}$/v.test("*\uFE0F\u20E3")
+          && !/^\p{Emoji_Keycap_Sequence}$/v.test("*");
+        */},
+        res: {
+          chrome110: false,
+          chrome111: chrome.harmony,
+          chrome112: true,
+          firefox91: false,
+          firefox102: false,
+          firefox115: false,
+          firefox116: true,
+          ie11: false,
+          safari16_6: false,
+          safari17: true,
+          safaritp: true,
+          rhino1_7_15: false,
+        }
+      },
+      {
+        name: 'constructor supports it',
+        exec: function () {/*
+            return new RegExp('a', 'v') instanceof RegExp;
+        */},
+        res: {
+          chrome110: false,
+          chrome111: chrome.harmony,
+          chrome112: true,
+          firefox91: false,
+          firefox102: false,
+          firefox115: false,
+          firefox116: true,
+          ie11: false,
+          safari16_6: false,
+          safari17: true,
+          safaritp: true,
+          rhino1_7_15: false,
+        }
+      },
+      {
+        name: 'shows up in flags',
+        exec: function () {/*
+          var flags = [];
+          var p = new Proxy({}, { get: function (o, k) { flags.push(k); return o[k]; }});
+          Object.getOwnPropertyDescriptor(RegExp.prototype, 'flags').get.call(p);
+          return flags.indexOf("unicodeSets") !== -1;
+        */},
+        res: {
+          chrome110: false,
+          chrome111: chrome.harmony,
+          chrome112: true,
+          firefox91: false,
+          firefox102: false,
+          firefox115: false,
+          firefox116: true,
+          ie11: false,
+          safari16_6: false,
+          safari17: true,
+          safaritp: true,
+          rhino1_7_15: false,
+        }
+      },
+      {
+        name: 'Unicode 15.1',
+        exec: function () {/*
+        return /^\p{RGI_Emoji}$/v.test("🐦‍🔥");
+      */},
+        res: {
+          chrome117: false,
+          chrome118: false,
+          chrome124: false,
+          chrome125: true,
+          chrome126: true,
+          node20_0: false,
+          node21_0: false,
+          node22_0: true,
+          firefox115: false,
+          firefox117: false,
+          firefox118: false,
+          safaritp: false,
+          safari16_6: false,
+          safari18: true,
+          ie11: false,
+          duktape2_0: false,
+          jerryscript2_3_0: false,
+          hermes0_7_0: false,
+          rhino1_7_13: false,
+        }
+      },
+      {
+        name: 'Unicode 16.0',
+        exec: function () {/*
+        return /^\p{RGI_Emoji}$/v.test("🇨🇶");
+      */},
+        res: {
+          chrome128: false,
+          node22_0: false,
+          firefox115: false,
+          firefox130: false,
+          safari17_6: false,
+        }
+      }
+    ]
+  },
+  {
+    name: 'ArrayBuffer.prototype.transfer',
+    category: '2024 features',
+    significance: 'small',
+    spec: 'https://github.com/tc39/proposal-arraybuffer-transfer',
+    subtests: [
+      {
+        name: 'ArrayBuffer.prototype.transfer()',
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transfer',
+        exec: function () {/*
+          const buffer1 = new Uint8Array([1, 2]).buffer;
+          const buffer2 = buffer1.transfer();
+          return buffer1.byteLength === 0
+            && buffer2.byteLength === 2;
+        */},
+        res: {
+          ie11: false,
+          firefox10: false,
+          firefox52: false,
+          firefox117: {
+            val: 'flagged',
+            note_id: 'firefox-arraybuffer',
+            note_html: 'The feature has to be enabled via <code>javascript.options.experimental.arraybuffer_transfer</code> setting under <code>about:config</code>.'
+          },
+          firefox122: true,
+          chrome70: false,
+          chrome114: true,
+          safari12: false,
+          safari17_4: true,
+          duktape2_0: false,
+          graalvm21_3_3: false,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: 'ArrayBuffer.prototype.transferToFixedLength()',
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transferToFixedLength',
+        exec: function () {/*
+          const buffer1 = new Uint8Array([1, 2]).buffer;
+          const buffer2 = buffer1.transferToFixedLength();
+          return buffer1.byteLength === 0
+            && buffer2.byteLength === 2;
+        */},
+        res: {
+          ie11: false,
+          firefox115: false,
+          firefox117: {
+            val: 'flagged',
+            note_id: 'firefox-arraybuffer',
+          },
+          firefox122: true,
+          chrome114: true,
+          safari17_4: true,
+        }
+      },
+      {
+        name: 'ArrayBuffer.prototype.detached',
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/detached',
+        exec: function () {/*
+          const buffer1 = new Uint8Array([1, 2]).buffer;
+          const buffer2 = buffer1.transfer();
+          return buffer1.detached && !buffer2.detached;
+        */},
+        res: {
+          ie11: false,
+          firefox115: false,
+          firefox117: {
+            val: 'flagged',
+            note_id: 'firefox-arraybuffer',
+          },
+          firefox122: true,
+          chrome114: true,
+          safari17_4: true,
+        }
+      },
+    ]
+  },
+  {
+    name: 'Promise.withResolvers',
+    category: '2024 features',
+    significance: 'tiny',
+    spec: 'https://tc39.es/proposal-promise-with-resolvers/',
+    mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers',
+    exec: function () {/*
+      var obj = Promise.withResolvers();
+      return obj instanceof Object
+        && obj.promise instanceof Promise
+        && typeof obj.resolve === 'function'
+        && typeof obj.reject === 'function';
+    */},
+    res: {
+      chrome119: true,
+      firefox115: false,
+      firefox121: true,
+      node22_0: true,
+      safari17_6: true,
+      safaritp: true,
+    }
+  },
+  {
+    name: 'Array Grouping',
+    category: '2024 features',
+    significance: 'small',
+    spec: 'https://github.com/tc39/proposal-array-grouping',
+    subtests: [
+      {
+        name: 'Object.groupBy()',
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/groupBy',
+        exec: function () {/*
+          const array = [1, 2, 3, 4];
+          const obj = Object.groupBy(array, (num, index) => {
+            return num % 2 === 0 ? 'even': 'odd';
+          });
+          return !('toString' in obj) && obj.even[0] == 2 && obj.odd[0] == 1;
+        */},
+        res: {
+          ie11: false,
+          chrome117: true,
+          firefox97: false,
+          firefox98: {
+            val: 'flagged',
+            note_id: 'ff-array-grouping',
+            note_html: 'The feature is only available on Nightly builds, and has to be enabled via <code>javascript.options.experimental.array_grouping</code> setting under <code>about:config</code>.'
+          },
+          firefox119: true,
+          safari17_4: true,
+        }
+      },
+      {
+        name: 'Map.groupBy()',
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/groupBy',
+        exec: function () {/*
+          const array = [1, 2, 3, 4];
+          const odd  = { odd: true };
+          const even = { even: true };
+          const map = Map.groupBy(array, (num, index) => {
+            return num % 2 === 0 ? even: odd;
+          });
+          return map instanceof Map && map.get(even)[0] === 2 && map.get(odd)[0] === 1;
+        */},
+        res: {
+          ie11: false,
+          chrome117: true,
+          firefox97: false,
+          firefox98: {
+            val: 'flagged',
+            note_id: 'ff-array-grouping',
+          },
+          firefox119: true,
+          safari17_4: true,
+        }
+      },
+    ]
+  },
+  {
+    name: 'Duplicate named capturing groups',
+    category: '2025 features',
+    significance: 'tiny',
+    spec: 'https://github.com/tc39/proposal-duplicate-named-capturing-groups',
+    exec: function () {/*
+    return /(?<year>[0-9]{4})-[0-9]{2}|[0-9]{2}-(?<year>[0-9]{4})/.test("12-1995");
+    */},
+    res: {
+      chrome123: false,
+      chrome126: true,
+      deno1_42: false,
+      node21_0: false,
+      firefox115: false,
+      firefox128: false,
+      firefox129: true,
+      safari17_4: true,
+      safaritp: true,
+      ie11: false,
+      duktape2_0: false,
+      jerryscript2_3_0: false,
+      hermes0_7_0: false,
+      rhino1_7_13: false,
+    }
+  },
+  {
+    name: 'Set methods',
+    category: '2025 features',
+    significance: 'medium',
+    spec: 'https://github.com/tc39/proposal-set-methods',
+    mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#instance_methods',
+    subtests: [
+      {
+        name: 'Set.prototype.intersection()',
+        exec: function () {/*
+          var set = new Set([1, 2, 3]).intersection(new Set([2, 3, 4]));
+          return set.size === 2
+            && set.has(2)
+            && set.has(3);
+        */},
+        res: {
+          babel6corejs2: false,
+          babel7corejs3: babel.corejs,
+          typescript1corejs2: typescript.fallthrough,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          firefox2: false,
+          firefox117: false,
+          firefox118: {
+            val: 'flagged',
+            note_id: 'ff-new-set-methods',
+            note_html: 'The feature has to be enabled via <code>javascript.options.experimental.new_set_methods</code> setting under <code>about:config</code>.'
+          },
+          firefox127: true,
+          chrome77: false,
+          chrome122: true,
+          safari17: true,
+          duktape2_0: false,
+          graalvm19: false,
+          graalvm21_3_3: graalvm.newSetMethodsFlag,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: 'Set.prototype.union()',
+        exec: function () {/*
+          var set = new Set([1, 2]).union(new Set([2, 3]));
+          return set.size === 3
+            && set.has(1)
+            && set.has(2)
+            && set.has(3);
+        */},
+        res: {
+          babel6corejs2: false,
+          babel7corejs3: babel.corejs,
+          typescript1corejs2: typescript.fallthrough,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          firefox2: false,
+          firefox117: false,
+          firefox118: {
+            val: 'flagged',
+            note_id: 'ff-new-set-methods'
+          },
+          firefox127: true,
+          chrome77: false,
+          chrome122: true,
+          safari17: true,
+          duktape2_0: false,
+          graalvm19: false,
+          graalvm21_3_3: graalvm.newSetMethodsFlag,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: 'Set.prototype.difference()',
+        exec: function () {/*
+          var set = new Set([1, 2, 3]).difference(new Set([3, 4]));
+          return set.size === 2
+            && set.has(1)
+            && set.has(2);
+        */},
+        res: {
+          babel6corejs2: false,
+          babel7corejs3: babel.corejs,
+          typescript1corejs2: typescript.fallthrough,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          firefox2: false,
+          firefox117: false,
+          firefox118: {
+            val: 'flagged',
+            note_id: 'ff-new-set-methods'
+          },
+          firefox127: true,
+          chrome77: false,
+          chrome122: true,
+          safari17: true,
+          duktape2_0: false,
+          graalvm19: false,
+          graalvm21_3_3: graalvm.newSetMethodsFlag,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: 'Set.prototype.symmetricDifference()',
+        exec: function () {/*
+          var set = new Set([1, 2]).symmetricDifference(new Set([2, 3]));
+          return set.size === 2
+            && set.has(1)
+            && set.has(3);
+        */},
+        res: {
+          babel6corejs2: false,
+          babel7corejs3: babel.corejs,
+          typescript1corejs2: typescript.fallthrough,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          firefox2: false,
+          firefox117: false,
+          firefox118: {
+            val: 'flagged',
+            note_id: 'ff-new-set-methods'
+          },
+          firefox127: true,
+          chrome77: false,
+          chrome122: true,
+          safari17: true,
+          duktape2_0: false,
+          graalvm19: false,
+          graalvm21_3_3: graalvm.newSetMethodsFlag,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: 'Set.prototype.isDisjointFrom()',
+        exec: function () {/*
+          return new Set([1, 2, 3]).isDisjointFrom(new Set([4, 5, 6]));
+        */},
+        res: {
+          babel6corejs2: false,
+          babel7corejs3: babel.corejs,
+          typescript1corejs2: typescript.fallthrough,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          firefox2: false,
+          firefox117: false,
+          firefox118: {
+            val: 'flagged',
+            note_id: 'ff-new-set-methods'
+          },
+          firefox127: true,
+          chrome77: false,
+          chrome122: true,
+          safari17: true,
+          duktape2_0: false,
+          graalvm19: false,
+          graalvm20_1: graalvm.es2021flag,
+          graalvm21_3_3: graalvm.newSetMethodsFlag,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: 'Set.prototype.isSubsetOf()',
+        exec: function () {/*
+          return new Set([1, 2, 3]).isSubsetOf(new Set([5, 4, 3, 2, 1]));
+        */},
+        res: {
+          babel6corejs2: false,
+          babel7corejs3: babel.corejs,
+          typescript1corejs2: typescript.fallthrough,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          firefox2: false,
+          firefox117: false,
+          firefox118: {
+            val: 'flagged',
+            note_id: 'ff-new-set-methods'
+          },
+          firefox127: true,
+          chrome77: false,
+          chrome122: true,
+          safari17: true,
+          duktape2_0: false,
+          graalvm19: false,
+          graalvm21_3_3: graalvm.newSetMethodsFlag,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: 'Set.prototype.isSupersetOf()',
+        exec: function () {/*
+          return new Set([5, 4, 3, 2, 1]).isSupersetOf(new Set([1, 2, 3]));
+        */},
+        res: {
+          babel6corejs2: false,
+          babel7corejs3: babel.corejs,
+          typescript1corejs2: typescript.fallthrough,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          firefox2: false,
+          firefox117: false,
+          firefox118: {
+            val: 'flagged',
+            note_id: 'ff-new-set-methods'
+          },
+          firefox127: true,
+          chrome77: false,
+          chrome122: true,
+          safari17: true,
+          duktape2_0: false,
+          graalvm19: false,
+          graalvm21_3_3: graalvm.newSetMethodsFlag,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      }
+    ]
+  },
+  {
+    name: 'RegExp Pattern Modifiers',
+    category: '2025 features',
+    significance: 'medium',
+    spec: 'https://github.com/tc39/proposal-regexp-modifiers',
+    subtests: [
+      {
+        name: 'i flag',
+        exec: function () {/*
+          const regex = /^[a-z](?-i:[a-z])$/i;
+          return regex.test("ab") && regex.test("Ab") && !regex.test("aB");
+        */},
+        res: {
+          chrome121: false,
+          chrome122: chrome.harmony,
+          chrome124: chrome.harmony,
+          chrome125: true,
+          firefox127: false,
+          firefox129: false,
+          firefox130: {
+            val: 'flagged',
+            note_id: 'ff-regexp-modidiers',
+            note_html: 'The feature has to be enabled via <code>javascript.options.experimental.regexp_modifiers</code> setting under <code>about:config</code>.'
+          },
+          firefox132: true,
+          safari17_5: false,
+        }
+      },
+      {
+        name: 'm flag',
+        exec: function () {/*
+          const regex = /^a|(?m:^b)/;
+          return regex.test("a") && regex.test("b") && regex.test("c\nb") && !regex.test("c\na");
+        */},
+        res: {
+          chrome121: false,
+          chrome122: chrome.harmony,
+          chrome124: chrome.harmony,
+          chrome125: true,
+          firefox127: false,
+          firefox129: false,
+          firefox130: {
+            val: 'flagged',
+            note_id: 'ff-regexp-modidiers',
+          },
+          firefox132: true,
+          safari17_5: false,
+        }
+      },
+      {
+        name: 's flag',
+        exec: function () {/*
+          const regex = /.(?-s:.)/s;
+          return regex.test("\na") && regex.test("aa") && !regex.test("\n\n");
+        */},
+        res: {
+          chrome121: false,
+          chrome122: chrome.harmony,
+          chrome124: chrome.harmony,
+          chrome125: true,
+          firefox127: false,
+          firefox129: false,
+          firefox130: {
+            val: 'flagged',
+            note_id: 'ff-regexp-modidiers',
+          },
+          firefox132: true,
+          safari17_5: false,
+        }
+      },
+    ]
+  },
+  {
+    name: 'Iterator Helpers',
+    category: '2025 features',
+    significance: 'large',
+    spec: 'https://github.com/tc39/proposal-iterator-helpers',
+    mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator#iterator_helpers',
+    subtests: [
+      {
+        name: 'instanceof Iterator',
+        exec: function () {/*
+          return [1, 2, 3].values() instanceof Iterator;
+        */},
+        res: {
+          babel6corejs2: false,
+          babel7corejs3: babel.corejs,
+          typescript1corejs2: typescript.fallthrough,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          firefox10: false,
+          firefox60: false,
+          firefox116: false,
+          firefox117: {
+            val: 'flagged',
+            note_id: 'ff-iterator-helpers',
+            note_html: 'The feature is only available on Nightly builds, and has to be enabled via <code>javascript.options.experimental.iterator_helpers</code> setting under <code>about:config</code>.'
+          },
+          firefox131: true,
+          chrome77: false,
+          chrome126: true,
+          duktape2_0: false,
+          graalvm21_3_3: false,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: 'extends Iterator',
+        exec: function () {/*
+          class Class extends Iterator { }
+          const instance = new Class();
+          return instance[Symbol.iterator]() === instance;
+        */},
+        res: {
+          babel6corejs2: false,
+          babel7corejs3: babel.corejs,
+          typescript1corejs2: typescript.fallthrough,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          firefox10: false,
+          firefox60: false,
+          firefox116: false,
+          firefox117: {
+            val: 'flagged',
+            note_id: 'ff-iterator-helpers'
+          },
+          firefox131: true,
+          chrome77: false,
+          chrome126: true,
+          duktape2_0: false,
+          graalvm21_3_3: false,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: 'Iterator.from, iterable',
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/from',
+        exec: function () {/*
+          const iterator = Iterator.from([1, 2, 3]);
+          return 'next' in iterator
+            && iterator instanceof Iterator
+            && Array.from(iterator).join() === '1,2,3';
+        */},
+        res: {
+          babel6corejs2: false,
+          babel7corejs3: babel.corejs,
+          typescript1corejs2: typescript.fallthrough,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          firefox10: false,
+          firefox60: false,
+          firefox116: false,
+          firefox117: {
+            val: 'flagged',
+            note_id: 'ff-iterator-helpers'
+          },
+          firefox131: true,
+          chrome77: false,
+          chrome126: true,
+          duktape2_0: false,
+          graalvm21_3_3: false,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: 'Iterator.from, iterator',
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/from',
+        exec: function () {/*
+          const iterator = Iterator.from({
+            i: 0,
+            next() {
+              return { value: ++this.i, done: this.i > 3 };
+            }
+          });
+          return 'next' in iterator
+            && iterator instanceof Iterator
+            && Array.from(iterator).join() === '1,2,3';
+        */},
+        res: {
+          babel6corejs2: false,
+          babel7corejs3: babel.corejs,
+          typescript1corejs2: typescript.fallthrough,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          firefox10: false,
+          firefox60: false,
+          firefox116: false,
+          firefox117: {
+            val: 'flagged',
+            note_id: 'ff-iterator-helpers'
+          },
+          firefox131: true,
+          chrome77: false,
+          chrome126: true,
+          duktape2_0: false,
+          graalvm21_3_3: false,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: 'Iterator.prototype.drop',
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/drop',
+        exec: function () {/*
+          return Array.from([1, 2, 3].values().drop(1)).join() === '2,3';
+        */},
+        res: {
+          babel6corejs2: false,
+          babel7corejs3: babel.corejs,
+          typescript1corejs2: typescript.fallthrough,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          firefox10: false,
+          firefox60: false,
+          firefox116: false,
+          firefox117: {
+            val: 'flagged',
+            note_id: 'ff-iterator-helpers'
+          },
+          firefox131: true,
+          chrome77: false,
+          chrome126: true,
+          duktape2_0: false,
+          graalvm21_3_3: false,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: 'Iterator.prototype.every',
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/every',
+        exec: function () {/*
+          return [1, 2, 3].values().every(it => typeof it === 'number');
+        */},
+        res: {
+          babel6corejs2: false,
+          babel7corejs3: babel.corejs,
+          typescript1corejs2: typescript.fallthrough,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          firefox10: false,
+          firefox60: false,
+          firefox116: false,
+          firefox117: {
+            val: 'flagged',
+            note_id: 'ff-iterator-helpers'
+          },
+          firefox131: true,
+          chrome77: false,
+          chrome126: true,
+          duktape2_0: false,
+          graalvm21_3_3: false,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: 'Iterator.prototype.filter',
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/filter',
+        exec: function () {/*
+          return Array.from([1, 2, 3].values().filter(it => it % 2)).join() === '1,3';
+        */},
+        res: {
+          babel6corejs2: false,
+          babel7corejs3: babel.corejs,
+          typescript1corejs2: typescript.fallthrough,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          firefox10: false,
+          firefox60: false,
+          firefox116: false,
+          firefox117: {
+            val: 'flagged',
+            note_id: 'ff-iterator-helpers'
+          },
+          firefox131: true,
+          chrome77: false,
+          chrome126: true,
+          duktape2_0: false,
+          graalvm21_3_3: false,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: 'Iterator.prototype.find',
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/find',
+        exec: function () {/*
+          return [1, 2, 3].values().find(it => it % 2) === 1;
+        */},
+        res: {
+          babel6corejs2: false,
+          babel7corejs3: babel.corejs,
+          typescript1corejs2: typescript.fallthrough,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          firefox10: false,
+          firefox60: false,
+          firefox116: false,
+          firefox117: {
+            val: 'flagged',
+            note_id: 'ff-iterator-helpers'
+          },
+          firefox131: true,
+          chrome77: false,
+          chrome126: true,
+          duktape2_0: false,
+          graalvm21_3_3: false,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: 'Iterator.prototype.flatMap',
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/flatMap',
+        exec: function () {/*
+          return Array.from([1, 2, 3].values().flatMap(it => [it, 0])).join() === '1,0,2,0,3,0';
+        */},
+        res: {
+          babel6corejs2: false,
+          babel7corejs3: babel.corejs,
+          typescript1corejs2: typescript.fallthrough,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          firefox10: false,
+          firefox60: false,
+          firefox116: false,
+          firefox117: {
+            val: 'flagged',
+            note_id: 'ff-iterator-helpers'
+          },
+          firefox131: true,
+          chrome77: false,
+          chrome126: true,
+          duktape2_0: false,
+          graalvm21_3_3: false,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: 'Iterator.prototype.forEach',
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/forEach',
+        exec: function () {/*
+          let result = '';
+          [1, 2, 3].values().forEach(it => result += it);
+          return result === '123';
+        */},
+        res: {
+          babel6corejs2: false,
+          babel7corejs3: babel.corejs,
+          typescript1corejs2: typescript.fallthrough,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          firefox10: false,
+          firefox60: false,
+          firefox116: false,
+          firefox117: {
+            val: 'flagged',
+            note_id: 'ff-iterator-helpers'
+          },
+          firefox131: true,
+          chrome77: false,
+          chrome126: true,
+          duktape2_0: false,
+          graalvm21_3_3: false,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: 'Iterator.prototype.map',
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/map',
+        exec: function () {/*
+          return Array.from([1, 2, 3].values().map(it => it * it)).join() === '1,4,9';
+        */},
+        res: {
+          babel6corejs2: false,
+          babel7corejs3: babel.corejs,
+          typescript1corejs2: typescript.fallthrough,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          firefox10: false,
+          firefox60: false,
+          firefox116: false,
+          firefox117: {
+            val: 'flagged',
+            note_id: 'ff-iterator-helpers'
+          },
+          firefox131: true,
+          chrome77: false,
+          chrome126: true,
+          duktape2_0: false,
+          graalvm21_3_3: false,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: 'Iterator.prototype.reduce',
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/reduce',
+        exec: function () {/*
+          return [1, 2, 3].values().reduce((a, b) => a + b) === 6;
+        */},
+        res: {
+          babel6corejs2: false,
+          babel7corejs3: babel.corejs,
+          typescript1corejs2: typescript.fallthrough,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          firefox10: false,
+          firefox60: false,
+          firefox116: false,
+          firefox117: {
+            val: 'flagged',
+            note_id: 'ff-iterator-helpers'
+          },
+          firefox131: true,
+          chrome77: false,
+          chrome126: true,
+          duktape2_0: false,
+          graalvm21_3_3: false,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: 'Iterator.prototype.some',
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/some',
+        exec: function () {/*
+          return [1, 2, 3].values().some(it => typeof it === 'number');
+        */},
+        res: {
+          babel6corejs2: false,
+          babel7corejs3: babel.corejs,
+          typescript1corejs2: typescript.fallthrough,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          firefox10: false,
+          firefox60: false,
+          firefox116: false,
+          firefox117: {
+            val: 'flagged',
+            note_id: 'ff-iterator-helpers'
+          },
+          firefox131: true,
+          chrome77: false,
+          chrome126: true,
+          duktape2_0: false,
+          graalvm21_3_3: false,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: 'Iterator.prototype.take',
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/take',
+        exec: function () {/*
+          return Array.from([1, 2, 3].values().take(2)).join() === '1,2';
+        */},
+        res: {
+          babel6corejs2: false,
+          babel7corejs3: babel.corejs,
+          typescript1corejs2: typescript.fallthrough,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          firefox10: false,
+          firefox60: false,
+          firefox116: false,
+          firefox117: {
+            val: 'flagged',
+            note_id: 'ff-iterator-helpers'
+          },
+          firefox131: true,
+          chrome77: false,
+          chrome126: true,
+          duktape2_0: false,
+          graalvm21_3_3: false,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: 'Iterator.prototype.toArray',
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/toArray',
+        exec: function () {/*
+          const array = [1, 2, 3].values().toArray();
+          return Array.isArray(array) && array.join() === '1,2,3';
+        */},
+        res: {
+          babel6corejs2: false,
+          babel7corejs3: babel.corejs,
+          typescript1corejs2: typescript.fallthrough,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          firefox10: false,
+          firefox60: false,
+          firefox116: false,
+          firefox117: {
+            val: 'flagged',
+            note_id: 'ff-iterator-helpers'
+          },
+          firefox131: true,
+          chrome77: false,
+          chrome126: true,
+          duktape2_0: false,
+          graalvm21_3_3: false,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      },
+      {
+        name: 'Iterator.prototype[@@toStringTag]',
+        exec: function () {/*
+          return Iterator.prototype[Symbol.toStringTag] === 'Iterator';
+        */},
+        res: {
+          babel6corejs2: false,
+          babel7corejs3: babel.corejs,
+          typescript1corejs2: typescript.fallthrough,
+          typescript3_2corejs3: typescript.corejs,
+          ie11: false,
+          firefox10: false,
+          firefox60: false,
+          firefox116: false,
+          firefox117: {
+            val: 'flagged',
+            note_id: 'ff-iterator-helpers'
+          },
+          firefox131: true,
+          chrome77: false,
+          chrome126: true,
+          duktape2_0: false,
+          graalvm21_3_3: false,
+          hermes0_7_0: false,
+          reactnative0_70_3: false,
+          rhino1_7_13: false
+        }
+      },
+    ]
+  },
+  {
+    name: 'Promise.try',
+    category: '2025 features',
+    significance: 'tiny',
+    spec: 'https://github.com/tc39/proposal-promise-try',
+    mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/try',
+    exec: function () {/*
+      var called = false;
+      var argsMatch = false;
+      var p = Promise.try(function () { called = true; })
+      var p2 = Promise.try(function () {
+        'use strict';
+        argsMatch = this === undefined && arguments.length === 2 && args[0] === p && args[1] === 2;
+      }, [p, 2]);
+
+      return p instanceof Promise && called && argsMatch;
+    */},
+    res: {
+      chrome128: true,
+      firefox115: false,
+      firefox131: false,
+      firefox132: {
+        val: 'flagged',
+        note_id: 'ff-promise-try',
+        note_html: 'The feature is only available on Nightly builds, and has to be enabled via <code>javascript.options.experimental.promise_try</code> setting under <code>about:config</code>.'
+      },
+      node23: true,
+    }
+  }
 ];
 
 //Shift annex B features to the bottom
-exports.tests = exports.tests.reduce(function(a,e) {
-  var index = ['2016 features', '2016 misc', '2017 features', '2017 misc', '2017 annex b', '2018 features', '2018 misc', '2019 features', '2019 misc', '2020 features', '2021 features', '2022 features', '2023 features', 'finished (stage 4)'].indexOf(e.category);
+exports.tests = exports.tests.reduce(function (a, e) {
+  var index = ['2016 features', '2016 misc', '2017 features', '2017 misc', '2017 annex b', '2018 features', '2018 misc', '2019 features', '2019 misc', '2020 features', '2021 features', '2022 features', '2023 features', '2024 features', '2025 features', 'finished (stage 4)'].indexOf(e.category);
   if (index === -1) {
     console.log('"' + a.category + '" is not an ES2016+ category!');
   }
   (a[index] = a[index] || []).push(e);
   return a;
-},[]).reduce(function(a,e) {
+},[]).reduce(function (a, e) {
   return a.concat(e);
 },[]);

--- a/test/ecmascript/data-es5.js
+++ b/test/ecmascript/data-es5.js
@@ -975,7 +975,8 @@ exports.tests = [
         safari15: true,
         graalvm21_3_3: true,
         hermes0_7_0: true,
-        reactnative0_70_3: true
+        reactnative0_70_3: true,
+        rhino1_7_15: true,
       }
     }
   ],
@@ -1081,7 +1082,8 @@ exports.tests = [
       opera11: true,
       graalvm21_3_3: true,
       hermes0_7_0: true,
-      reactnative0_70_3: true
+      reactnative0_70_3: true,
+      rhino1_7_15: true,
     }
   },
   {
@@ -2211,7 +2213,8 @@ exports.tests = [
       jerryscript1_0: true,
       hermes0_7_0: true,
       reactnative0_70_3: true,
-      rhino1_7_13: true
+      rhino1_7_13: false,
+      rhino1_7_15: false
     }
   },
   {

--- a/test/ecmascript/data-es6.js
+++ b/test/ecmascript/data-es6.js
@@ -61,7 +61,8 @@ exports.tests = [
         jerryscript2_0: false,
         hermes0_7_0: false,
         reactnative0_70_3: false,
-        rhino1_7_13: true
+        rhino1_7_13: false,
+        rhino1_7_15: false,
       }
     },
     {
@@ -98,7 +99,8 @@ exports.tests = [
         jerryscript2_0: false,
         hermes0_7_0: false,
         reactnative0_70_3: false,
-        rhino1_7_13: true
+        rhino1_7_13: false,
+        rhino1_7_15: false,
       }
     }
   ]
@@ -2170,7 +2172,8 @@ exports.tests = [
         jerryscript2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -2202,7 +2205,8 @@ exports.tests = [
         jerryscript2_0: true,
         hermes0_7_0: false,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -2308,7 +2312,8 @@ exports.tests = [
         jerryscript2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     }
   ],
@@ -2785,6 +2790,7 @@ exports.tests = [
         tr: true,
         babel7corejs3: babel.corejs,
         typescript1corejs2: typescript.notDownlevelIteration,
+        closure20230228: true,
         es6tr: true,
         ie11: false,
         edge12: true,
@@ -4732,7 +4738,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -4769,7 +4776,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -5536,7 +5544,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -5579,7 +5588,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -5603,6 +5613,7 @@ exports.tests = [
         tr: true,
         babel6corejs2: false,
         typescript1corejs2: false,
+        closure20230228: true,
         firefox2: false,
         firefox27: true,
         opera10_50: false,
@@ -5667,7 +5678,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -5710,7 +5722,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -6338,7 +6351,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -6633,7 +6647,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -6669,7 +6684,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -8193,7 +8209,8 @@ exports.tests = [
       jerryscript2_2_0: true,
       hermes0_7_0: false,
       reactnative0_70_3: false,
-      rhino1_7_13: false
+      rhino1_7_13: false,
+      rhino1_7_15: true,
     }}
     ].map(function(m) {
       var eqFn = ' === "function"';
@@ -8436,7 +8453,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -8889,7 +8907,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: false,
         reactnative0_70_3: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     }
   ],
@@ -9116,7 +9135,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -9571,7 +9591,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: false,
         reactnative0_70_3: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     }
   ],
@@ -9830,7 +9851,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -10233,7 +10255,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -12197,12 +12220,15 @@ exports.tests = [
         // RegExp.prototype.flags -> Get -> [[Get]]
         var expected = [];
         // Sorted alphabetically by shortname – "gimsuy".
+        if ('hasIndices' in RegExp.prototype) expected.push('hasIndices');
         if ('global' in RegExp.prototype) expected.push('global');
         if ('ignoreCase' in RegExp.prototype) expected.push('ignoreCase');
         if ('multiline' in RegExp.prototype) expected.push('multiline');
         if ('dotAll' in RegExp.prototype) expected.push('dotAll');
         if ('unicode' in RegExp.prototype) expected.push('unicode');
+        if ('unicodeSets' in RegExp.prototype) expected.push('unicodeSets');
         if ('sticky' in RegExp.prototype) expected.push('sticky');
+
         var actual = [];
         var p = new Proxy({}, { get: function(o, k) { actual.push(k); return o[k]; }});
         Object.getOwnPropertyDescriptor(RegExp.prototype, 'flags').get.call(p);
@@ -12297,7 +12323,8 @@ exports.tests = [
         RegExp.prototype[Symbol.match].call(p);
         p.global = true;
         RegExp.prototype[Symbol.match].call(p);
-        return get + '' === "global,exec,global,unicode,exec";
+        var str = get + '';
+        return str === "global,exec,global,unicode,exec" || str === 'flags,exec,flags,exec';
       */},
       res: {
         ie11: false,
@@ -12326,7 +12353,8 @@ exports.tests = [
         RegExp.prototype[Symbol.replace].call(p);
         p.global = true;
         RegExp.prototype[Symbol.replace].call(p);
-        return get + '' === "global,exec,global,unicode,exec";
+        var str = get + '';
+        return str === "global,exec,global,unicode,exec" || str === 'flags,exec,flags,exec';
       */},
       res: {
         ie11: false,
@@ -16864,9 +16892,13 @@ exports.tests = [
     {
       name: 'duplicate identifier',
       exec: function(){/*
-        var d = function d([d]) { return d };
-        if (d([true]) !== true) return false;
-
+        try {
+          eval('var d = function d([d]) { return d };');
+          if (d([true]) !== true) return false;
+        } catch (e) {
+          return !(e instanceof SyntaxError);
+        }
+        
         try {
           eval('var f = function f([id, id]) { return id }');
           return false;
@@ -16883,8 +16915,9 @@ exports.tests = [
         closure: true,
         typescript1corejs2: true,
         firefox2: true,
-        safari13: false,
-        safari15: false,
+        safari11: false,
+        safari16_2: false,
+        safari16_3: true,
         edge13: edge.experimental,
         edge14: true,
         xs6: true,
@@ -16959,7 +16992,8 @@ exports.tests = [
         hermes0_7_0: false,
         hermes0_12_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -17076,7 +17110,8 @@ exports.tests = [
         hermes0_7_0: false,
         hermes0_12_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -17118,7 +17153,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: false,
         reactnative0_70_3: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -17164,7 +17200,8 @@ exports.tests = [
         hermes0_7_0: false,
         hermes0_12_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -17206,7 +17243,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: false,
         reactnative0_70_3: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -18037,7 +18075,8 @@ exports.tests = [
         jerryscript2_3_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -18435,7 +18474,8 @@ exports.tests = [
         jerryscript2_3_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     }
   ],
@@ -19027,7 +19067,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -19055,7 +19096,8 @@ exports.tests = [
         jerryscript2_4_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -19082,7 +19124,8 @@ exports.tests = [
         jerryscript2_4_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -19106,7 +19149,8 @@ exports.tests = [
         jerryscript2_4_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     }
   ]
@@ -19558,7 +19602,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -19760,7 +19805,8 @@ exports.tests = [
         firefox99: true,
         graalvm21_3_3: true,
         hermes0_7_0: true,
-        reactnative0_70_3: true
+        reactnative0_70_3: true,
+        rhino1_7_15: true,
       }
     },
     {
@@ -20290,7 +20336,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -20322,7 +20369,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -20354,7 +20402,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -20423,7 +20472,7 @@ exports.tests = [
         jerryscript2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
       }
     },
     {
@@ -20553,7 +20602,8 @@ exports.tests = [
         jerryscript2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -20628,7 +20678,8 @@ exports.tests = [
         jerryscript2_1_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -20769,7 +20820,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: false,
         reactnative0_70_3: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     }
   ]
@@ -21181,7 +21233,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -21212,7 +21265,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -21310,7 +21364,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -21342,7 +21397,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -21376,7 +21432,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -21440,7 +21497,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: false,
         reactnative0_70_3: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     }
   ],
@@ -21785,7 +21843,8 @@ exports.tests = [
         safari15: true,
         graalvm21_3_3: true,
         hermes0_7_0: true,
-        reactnative0_70_3: true
+        reactnative0_70_3: true,
+        rhino1_7_15: true,
       }
     },
     {
@@ -23886,7 +23945,8 @@ exports.tests = [
         jerryscript1_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -23934,7 +23994,8 @@ exports.tests = [
         jerryscript2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -23982,7 +24043,8 @@ exports.tests = [
         jerryscript1_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -24023,7 +24085,8 @@ exports.tests = [
         jerryscript1_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {
@@ -24212,7 +24275,8 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_4_0: true,
         hermes0_7_0: true,
-        reactnative0_70_3: true
+        reactnative0_70_3: true,
+        rhino1_7_15: true,
       }
     },
     {
@@ -24259,6 +24323,7 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: false,
         reactnative0_70_3: false,
+        rhino1_7_15: true,
       }
     }
   ],
@@ -24477,7 +24542,8 @@ exports.tests = [
         jerryscript2_2_0: true,
         hermes0_7_0: true,
         reactnative0_70_3: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        rhino1_7_15: true,
       }
     },
     {

--- a/test/ecmascript/data-esintl.js
+++ b/test/ecmascript/data-esintl.js
@@ -229,7 +229,8 @@ exports.tests = [
         graalvm20_1: true,
         hermes0_7_0: false,
         reactnative0_70_3: true,
-        rhino1_7_13: true
+        rhino1_7_13: false,
+        rhino1_7_15: false,
       }
     }
   ],
@@ -484,7 +485,8 @@ exports.tests = [
         graalvm19: true,
         hermes0_7_0: false,
         reactnative0_70_3: true,
-        rhino1_7_13: true
+        rhino1_7_13: false,
+        rhino1_7_15: false,
       }
     }
   ],
@@ -659,7 +661,8 @@ exports.tests = [
         graalvm20_1: true,
         hermes0_7_0: false,
         reactnative0_70_3: true,
-        rhino1_7_13: true
+        rhino1_7_13: false,
+        rhino1_7_15: false,
       }
     },
     {

--- a/test/ecmascript/data-esnext.js
+++ b/test/ecmascript/data-esnext.js
@@ -3,13 +3,14 @@ var common = require('./data-common');
 var babel = common.babel;
 var typescript = common.typescript;
 // var firefox = common.firefox;
-var graalvm = common.graalvm;
+// var graalvm = common.graalvm;
 
 exports.name = 'ES Next';
 exports.target_file = 'esnext/index.html';
 exports.skeleton_file = 'esnext/skeleton.html';
 
 var STAGE2 = 'Stage 2';
+var STAGE27 = 'Stage 2.7';
 var STAGE3 = 'Stage 3';
 
 exports.tests = [
@@ -42,7 +43,7 @@ exports.tests = [
 },
 {
   name: 'Class and Property Decorators',
-  category: STAGE2,
+  category: STAGE3,
   significance: 'medium',
   spec: 'https://github.com/tc39/proposal-decorators',
   subtests: [
@@ -78,7 +79,7 @@ exports.tests = [
 },
 {
   name: 'ShadowRealm',
-  category: STAGE3,
+  category: STAGE27,
   significance: 'large',
   spec: 'https://github.com/tc39/proposal-shadowrealm',
   exec: function () {/*
@@ -91,6 +92,12 @@ exports.tests = [
     ie11: false,
     firefox10: false,
     firefox52: false,
+    firefox103: false,
+    firefox107: {
+      val: 'flagged',
+      note_id: 'ff-shadow-realm',
+      note_html: 'The feature has to be enabled via <code>javascript.options.experimental.shadow_realms</code> setting under <code>about:config</code>.'
+    },
     opera10_50: false,
     chrome77: false,
     duktape2_0: false,
@@ -203,225 +210,6 @@ exports.tests = [
         chrome77: false,
         duktape2_0: false,
         graalvm19: false,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    }
-  ]
-},
-{
-  name: 'Set methods',
-  spec: 'https://github.com/tc39/proposal-set-methods',
-  category: STAGE2,
-  significance: 'medium',
-  subtests: [
-    {
-      name: 'Set.prototype.intersection',
-      exec: function () {/*
-        var set = new Set([1, 2, 3]).intersection(new Set([2, 3, 4]));
-        return set.size === 2
-          && set.has(2)
-          && set.has(3);
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox2: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm19: false,
-        graalvm21_3_3: graalvm.newSetMethodsFlag,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: 'Set.prototype.union',
-      exec: function () {/*
-        var set = new Set([1, 2]).union(new Set([2, 3]));
-        return set.size === 3
-          && set.has(1)
-          && set.has(2)
-          && set.has(3);
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox2: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm19: false,
-        graalvm21_3_3: graalvm.newSetMethodsFlag,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: 'Set.prototype.difference',
-      exec: function () {/*
-        var set = new Set([1, 2, 3]).difference(new Set([3, 4]));
-        return set.size === 2
-          && set.has(1)
-          && set.has(2);
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox2: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm19: false,
-        graalvm21_3_3: graalvm.newSetMethodsFlag,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: 'Set.prototype.symmetricDifference',
-      exec: function () {/*
-        var set = new Set([1, 2]).symmetricDifference(new Set([2, 3]));
-        return set.size === 2
-          && set.has(1)
-          && set.has(3);
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox2: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm19: false,
-        graalvm21_3_3: graalvm.newSetMethodsFlag,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: 'Set.prototype.isDisjointFrom',
-      exec: function () {/*
-        return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox2: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm19: false,
-        graalvm20_1: graalvm.es2021flag,
-        graalvm21_3_3: graalvm.newSetMethodsFlag,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: 'Set.prototype.isSubsetOf',
-      exec: function () {/*
-        return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox2: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm19: false,
-        graalvm21_3_3: graalvm.newSetMethodsFlag,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: 'Set.prototype.isSupersetOf',
-      exec: function () {/*
-        return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox2: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm19: false,
-        graalvm21_3_3: graalvm.newSetMethodsFlag,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    }
-  ]
-},
-{
-  name: 'ArrayBuffer.prototype.transfer',
-  category: STAGE2,
-  significance: 'small',
-  spec: 'https://github.com/domenic/proposal-arraybuffer-transfer/',
-  subtests: [
-    {
-      name: 'ArrayBuffer.prototype.transfer()',
-      exec: function () {/*
-        const buffer1 = new Uint8Array([1, 2]).buffer;
-        const buffer2 = buffer1.transfer();
-        return buffer1.byteLength === 0
-          && buffer2.byteLength === 2;
-      */},
-      res: {
-        ie11: false,
-        firefox10: false,
-        firefox52: false,
-        chrome70: false,
-        safari12: false,
-        duktape2_0: false,
-        graalvm21_3_3: false,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: 'ArrayBuffer.prototype.realloc()',
-      exec: function () {/*
-        const buffer1 = new ArrayBuffer(1024);
-        const buffer2 = buffer1.realloc(256);
-        return buffer1.byteLength === 0
-          && buffer2.byteLength === 256;
-      */},
-      res: {
-        ie11: false,
-        firefox10: false,
-        firefox52: false,
-        chrome70: false,
-        safari12: false,
-        duktape2_0: false,
-        graalvm21_3_3: false,
         hermes0_7_0: false,
         reactnative0_70_3: false,
         rhino1_7_13: false
@@ -581,384 +369,11 @@ exports.tests = [
   }
 },
 {
-  name: 'Iterator Helpers',
+  name: 'Async Iterator Helpers',
   category: STAGE2,
   significance: 'large',
-  spec: 'https://github.com/tc39/proposal-iterator-helpers',
+  spec: 'https://github.com/tc39/proposal-async-iterator-helpers',
   subtests: [
-    {
-      name: 'instanceof Iterator',
-      exec: function () {/*
-        return [1, 2, 3].values() instanceof Iterator;
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox10: false,
-        firefox60: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm21_3_3: false,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: 'extends Iterator',
-      exec: function () {/*
-        class Class extends Iterator { }
-        const instance = new Class();
-        return instance[Symbol.iterator]() === instance;
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox10: false,
-        firefox60: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm21_3_3: false,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: 'Iterator.from, iterable',
-      exec: function () {/*
-        const iterator = Iterator.from([1, 2, 3]);
-        return 'next' in iterator
-          && iterator instanceof Iterator
-          && Array.from(iterator).join() === '1,2,3';
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox10: false,
-        firefox60: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm21_3_3: false,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: 'Iterator.from, iterator',
-      exec: function () {/*
-        const iterator = Iterator.from({
-          i: 0,
-          next() {
-            return { value: ++this.i, done: this.i > 3 };
-          }
-        });
-        return 'next' in iterator
-          && iterator instanceof Iterator
-          && Array.from(iterator).join() === '1,2,3';
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox10: false,
-        firefox60: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm21_3_3: false,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: 'Iterator.prototype.asIndexedPairs',
-      exec: function () {/*
-        return Array.from([1, 2, 3].values().asIndexedPairs()).join() === '0,1,1,2,2,3';
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox10: false,
-        firefox60: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm21_3_3: false,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: 'Iterator.prototype.drop',
-      exec: function () {/*
-        return Array.from([1, 2, 3].values().drop(1)).join() === '2,3';
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox10: false,
-        firefox60: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm21_3_3: false,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: 'Iterator.prototype.every',
-      exec: function () {/*
-        return [1, 2, 3].values().every(it => typeof it === 'number');
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox10: false,
-        firefox60: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm21_3_3: false,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: 'Iterator.prototype.filter',
-      exec: function () {/*
-        return Array.from([1, 2, 3].values().filter(it => it % 2)).join() === '1,3';
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox10: false,
-        firefox60: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm21_3_3: false,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: 'Iterator.prototype.find',
-      exec: function () {/*
-        return [1, 2, 3].values().find(it => it % 2) === 1;
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox10: false,
-        firefox60: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm21_3_3: false,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: 'Iterator.prototype.flatMap',
-      exec: function () {/*
-        return Array.from([1, 2, 3].values().flatMap(it => [it, 0])).join() === '1,0,2,0,3,0';
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox10: false,
-        firefox60: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm21_3_3: false,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: 'Iterator.prototype.forEach',
-      exec: function () {/*
-        let result = '';
-        [1, 2, 3].values().forEach(it => result += it);
-        return result === '123';
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox10: false,
-        firefox60: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm21_3_3: false,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: 'Iterator.prototype.map',
-      exec: function () {/*
-        return Array.from([1, 2, 3].values().map(it => it * it)).join() === '1,4,9';
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox10: false,
-        firefox60: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm21_3_3: false,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: 'Iterator.prototype.reduce',
-      exec: function () {/*
-        return [1, 2, 3].values().reduce((a, b) => a + b) === 6;
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox10: false,
-        firefox60: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm21_3_3: false,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: 'Iterator.prototype.some',
-      exec: function () {/*
-        return [1, 2, 3].values().some(it => typeof it === 'number');
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox10: false,
-        firefox60: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm21_3_3: false,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: 'Iterator.prototype.take',
-      exec: function () {/*
-        return Array.from([1, 2, 3].values().take(2)).join() === '1,2';
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox10: false,
-        firefox60: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm21_3_3: false,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: 'Iterator.prototype.toArray',
-      exec: function () {/*
-        const array = [1, 2, 3].values().toArray();
-        return Array.isArray(array) && array.join() === '1,2,3';
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox10: false,
-        firefox60: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm21_3_3: false,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
-      name: 'Iterator.prototype[@@toStringTag]',
-      exec: function () {/*
-        return Iterator.prototype[Symbol.toStringTag] === 'Iterator';
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox10: false,
-        firefox60: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm21_3_3: false,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
     {
       name: 'instanceof AsyncIterator',
       exec: function () {/*
@@ -972,6 +387,16 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers',
+          note_html: 'The feature is only available on Nightly builds, and has to be enabled via <code>javascript.options.experimental.async_iterator_helpers</code> setting under <code>about:config</code>.'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -995,6 +420,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -1103,35 +537,6 @@ exports.tests = [
       }
     },
     {
-      name: 'AsyncIterator.prototype.asIndexedPairs',
-      exec: function () {/*
-        async function toArray(iterator) {
-          const result = [];
-          for await (const it of iterator) result.push(it);
-          return result;
-        }
-
-        toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it => {
-          if (it.join() === '0,1,1,2,2,3') asyncTestPassed();
-        });
-      */},
-      res: {
-        babel6corejs2: false,
-        babel7corejs3: babel.corejs,
-        typescript1corejs2: typescript.fallthrough,
-        typescript3_2corejs3: typescript.corejs,
-        ie11: false,
-        firefox10: false,
-        firefox60: false,
-        chrome77: false,
-        duktape2_0: false,
-        graalvm21_3_3: false,
-        hermes0_7_0: false,
-        reactnative0_70_3: false,
-        rhino1_7_13: false
-      }
-    },
-    {
       name: 'AsyncIterator.prototype.drop',
       exec: function () {/*
         async function toArray(iterator) {
@@ -1152,6 +557,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -1175,6 +589,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -1204,6 +627,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -1227,6 +659,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -1256,6 +697,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -1280,6 +730,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -1309,6 +768,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -1332,6 +800,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -1355,6 +832,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -1384,6 +870,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -1407,6 +902,15 @@ exports.tests = [
         ie11: false,
         firefox10: false,
         firefox60: false,
+        firefox116: false,
+        firefox117: {
+          val: 'flagged',
+          note_id: 'ff-iterator-helpers'
+        },
+        firefox128: {
+          val: 'flagged',
+          note_id: 'ff-async-iterator-helpers'
+        },
         chrome77: false,
         duktape2_0: false,
         graalvm21_3_3: false,
@@ -1438,12 +942,157 @@ exports.tests = [
     }
   ]
 },
+{
+  name: 'RegExp Escaping',
+  category: STAGE3,
+  significance: 'medium',
+  spec: 'https://github.com/tc39/proposal-regex-escaping',
+  exec: function () {/*
+    return RegExp.escape("The Quick Brown Fox") === "The\\ Quick\\ Brown\\ Fox" &&
+      RegExp.escape("(*.*)") === "\\(\\*\\.\\*\\)" &&
+      RegExp.escape("｡^･ｪ･^｡") === "｡\\^･ｪ･\\^｡" &&
+      RegExp.escape("\\d \\D (?:)") === "\\\\d \\\\D \\(\\?\\:\\)";
+  */},
+  res: {
+    chrome129: false,
+    firefox115: false,
+  }
+},
+{
+  name: 'Uint8Array to/from base64 and hex',
+  category: STAGE3,
+  significance: 'small',
+  spec: 'https://github.com/tc39/proposal-arraybuffer-base64',
+  subtests: [
+    {
+      name: 'Uint8Array.toBase64()',
+      exec: function () {/*
+        const arr = new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100]);
+        return arr.toBase64() === "SGVsbG8gV29ybGQ=";
+      */},
+      res: {
+        ie11: false,
+        chrome129: false,
+        firefox115: false,
+        firefox125: false,
+        firefox126: {
+          val: 'flagged',
+          note_id: 'ff-uint8-hex-base64',
+          note_html: 'The feature has to be enabled via <code>javascript.options.experimental.uint8array_base64</code> setting under <code>about:config</code>.'
+        },
+        firefox133: true,
+      }
+    },
+    {
+      name: 'Uint8Array.fromBase64()',
+      exec: function () {/*
+        const arr1 = new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100]);
+        const arr2 = Uint8Array.fromBase64("SGVsbG8gV29ybGQ=");
+        return arr1.length === arr2.length &&
+               arr1.every((element, index) => element === arr2[index]);
+      */},
+      res: {
+        ie11: false,
+        chrome129: false,
+        firefox115: false,
+        firefox125: false,
+        firefox126: {
+          val: 'flagged',
+          note_id: 'ff-uint8-hex-base64',
+        },
+        firefox133: true,
+
+      }
+    },
+    {
+      name: 'Uint8Array.setFromBase64()',
+      exec: function () {/*
+        const arr1 = new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100]);
+        let arr2 = new Uint8Array(16);
+        let { read, written } = arr2.setFromBase64("SGVsbG8gV29ybGQ=");
+        return read == 16 && written == 11 &&
+               arr1.every((element, index) => element === arr2[index]);
+      */},
+      res: {
+        ie11: false,
+        chrome129: false,
+        firefox115: false,
+        firefox125: false,
+        firefox126: {
+          val: 'flagged',
+          note_id: 'ff-uint8-hex-base64',
+        },
+        firefox133: true,
+      }
+    },
+    {
+      name: 'Uint8Array.toHex()',
+      exec: function () {/*
+        const arr = new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100]);
+        return arr.toHex() === "48656c6c6f20576f726c64";
+      */},
+      res: {
+        ie11: false,
+        chrome129: false,
+        firefox115: false,
+        firefox125: false,
+        firefox126: {
+          val: 'flagged',
+          note_id: 'ff-uint8-hex-base64',
+        },
+        firefox133: true,
+      }
+    },
+    {
+      name: 'Uint8Array.fromHex()',
+      exec: function () {/*
+        const arr1 = new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100]);
+        const arr2 = Uint8Array.fromHex("48656c6c6f20576f726c64");
+        return arr1.length === arr2.length &&
+               arr1.every((element, index) => element === arr2[index]);
+      */},
+      res: {
+        ie11: false,
+        chrome129: false,
+        firefox115: false,
+        firefox125: false,
+        firefox126: {
+          val: 'flagged',
+          note_id: 'ff-uint8-hex-base64',
+        },
+        firefox133: true,
+      }
+    },
+        {
+      name: 'Uint8Array.setFromHex()',
+      exec: function () {/*
+        const arr1 = new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100]);
+        let arr2 = new Uint8Array(16);
+        let { read, written } = arr2.setFromHex("48656c6c6f20576f726c64");
+        return read == 22 && written == 11 &&
+               arr1.every((element, index) => element === arr2[index]);
+      */},
+      res: {
+        ie11: false,
+        chrome129: false,
+        firefox115: false,
+        firefox125: false,
+        firefox126: {
+          val: 'flagged',
+          note_id: 'ff-uint8-hex-base64',
+        },
+        firefox133: true,
+      }
+    },
+
+  ]
+},
 ];
 
 
 //Shift annex B features to the bottom
 exports.tests = exports.tests.reduce(function(a,e) {
-  var index = [STAGE3, STAGE2].indexOf(e.category);
+  var index = [STAGE3, STAGE27, STAGE2].indexOf(e.category);
   if (index === -1) {
     console.log('"' + a.category + '" is not an ESnext category!');
   }


### PR DESCRIPTION
This PR updates the ecmascript tests using the instructions here:

https://github.com/vercel/nft/blob/main/test/ecmascript/README.md

We are currently failing a couple new test categories, `RegExp Pattern Modifiers` (stage 4) and `Duplicate named capturing groups` (stage 3), so those are skipped for now.

In a future PR, we can try updating `acorn` to see if fixes those tests.