### PR TITLE
fix: bump `@mapbox/node-pre-gyp@1.0.11`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.5",
+        "@mapbox/node-pre-gyp": "^1.0.11",
         "@rollup/pluginutils": "^4.0.0",
         "acorn": "^8.6.0",
         "acorn-import-attributes": "^1.9.5",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "prettier": "@vercel/style-guide/prettier",
   "dependencies": {
-    "@mapbox/node-pre-gyp": "^1.0.5",
+    "@mapbox/node-pre-gyp": "^1.0.11",
     "@rollup/pluginutils": "^4.0.0",
     "acorn": "^8.6.0",
     "acorn-import-attributes": "^1.9.5",


### PR DESCRIPTION
- Related to https://github.com/vercel/nft/issues/421