### PR TITLE
fix: avoid URL illegal constructor error

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -552,8 +552,8 @@ export default async function analyze(
       else if (computed.wildcards.length >= 1)
         emitWildcardRequire(computed.value);
     } else {
-      if ('then' in computed && typeof computed.then === 'string')
-        add(computed.then);
+      if ('ifTrue' in computed && typeof computed.ifTrue === 'string')
+        add(computed.ifTrue);
       if ('else' in computed && typeof computed.else === 'string')
         add(computed.else);
     }
@@ -585,8 +585,8 @@ export default async function analyze(
       if (
         ('value' in curStaticValue &&
           typeof curStaticValue.value !== 'symbol') ||
-        ('then' in curStaticValue &&
-          typeof curStaticValue.then !== 'symbol' &&
+        ('ifTrue' in curStaticValue &&
+          typeof curStaticValue.ifTrue !== 'symbol' &&
           typeof curStaticValue.else !== 'symbol')
       ) {
         staticChildValue = curStaticValue;
@@ -974,7 +974,7 @@ export default async function analyze(
             }
             if (
               !('value' in computed) &&
-              isAbsolutePathOrUrl(computed.then) &&
+              isAbsolutePathOrUrl(computed.ifTrue) &&
               isAbsolutePathOrUrl(computed.else)
             ) {
               staticChildValue = computed;
@@ -1196,14 +1196,14 @@ export default async function analyze(
         await emitAssetPath(resolved);
       } catch (e) {}
     } else if (
-      'then' in staticChildValue &&
+      'ifTrue' in staticChildValue &&
       'else' in staticChildValue &&
-      isAbsolutePathOrUrl(staticChildValue.then) &&
+      isAbsolutePathOrUrl(staticChildValue.ifTrue) &&
       isAbsolutePathOrUrl(staticChildValue.else)
     ) {
       let resolvedThen;
       try {
-        resolvedThen = resolveAbsolutePathOrUrl(staticChildValue.then);
+        resolvedThen = resolveAbsolutePathOrUrl(staticChildValue.ifTrue);
       } catch (e) {}
       let resolvedElse;
       try {

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,3 +1,0 @@
-import { nodeFileTrace } from './node-file-trace';
-
-nodeFileTrace(['./test/unit/a-url-error/input.js']);

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,0 +1,3 @@
+import { nodeFileTrace } from './node-file-trace';
+
+nodeFileTrace(['./test/unit/a-url-error/input.js']);

--- a/src/utils/static-eval.ts
+++ b/src/utils/static-eval.ts
@@ -16,7 +16,7 @@ export async function evaluate(
 
   // walk returns:
   // 1. Single known value: { value: value }
-  // 2. Conditional value: { test, then, else }
+  // 2. Conditional value: { test, ifTrue, else }
   // 3. Unknown value: undefined
   function walk(node: Node) {
     const visitor = visitors[node.type];
@@ -130,79 +130,79 @@ const visitors: Record<
     if ('test' in l && 'value' in r) {
       const v: any = r.value;
       if (op === '==')
-        return { test: l.test, then: l.then == v, else: l.else == v };
+        return { test: l.test, ifTrue: l.ifTrue == v, else: l.else == v };
       if (op === '===')
-        return { test: l.test, then: l.then === v, else: l.else === v };
+        return { test: l.test, ifTrue: l.ifTrue === v, else: l.else === v };
       if (op === '!=')
-        return { test: l.test, then: l.then != v, else: l.else != v };
+        return { test: l.test, ifTrue: l.ifTrue != v, else: l.else != v };
       if (op === '!==')
-        return { test: l.test, then: l.then !== v, else: l.else !== v };
+        return { test: l.test, ifTrue: l.ifTrue !== v, else: l.else !== v };
       if (op === '+')
-        return { test: l.test, then: l.then + v, else: l.else + v };
+        return { test: l.test, ifTrue: l.ifTrue + v, else: l.else + v };
       if (op === '-')
-        return { test: l.test, then: l.then - v, else: l.else - v };
+        return { test: l.test, ifTrue: l.ifTrue - v, else: l.else - v };
       if (op === '*')
-        return { test: l.test, then: l.then * v, else: l.else * v };
+        return { test: l.test, ifTrue: l.ifTrue * v, else: l.else * v };
       if (op === '/')
-        return { test: l.test, then: l.then / v, else: l.else / v };
+        return { test: l.test, ifTrue: l.ifTrue / v, else: l.else / v };
       if (op === '%')
-        return { test: l.test, then: l.then % v, else: l.else % v };
+        return { test: l.test, ifTrue: l.ifTrue % v, else: l.else % v };
       if (op === '<')
-        return { test: l.test, then: l.then < v, else: l.else < v };
+        return { test: l.test, ifTrue: l.ifTrue < v, else: l.else < v };
       if (op === '<=')
-        return { test: l.test, then: l.then <= v, else: l.else <= v };
+        return { test: l.test, ifTrue: l.ifTrue <= v, else: l.else <= v };
       if (op === '>')
-        return { test: l.test, then: l.then > v, else: l.else > v };
+        return { test: l.test, ifTrue: l.ifTrue > v, else: l.else > v };
       if (op === '>=')
-        return { test: l.test, then: l.then >= v, else: l.else >= v };
+        return { test: l.test, ifTrue: l.ifTrue >= v, else: l.else >= v };
       if (op === '|')
-        return { test: l.test, then: l.then | v, else: l.else | v };
+        return { test: l.test, ifTrue: l.ifTrue | v, else: l.else | v };
       if (op === '&')
-        return { test: l.test, then: l.then & v, else: l.else & v };
+        return { test: l.test, ifTrue: l.ifTrue & v, else: l.else & v };
       if (op === '^')
-        return { test: l.test, then: l.then ^ v, else: l.else ^ v };
+        return { test: l.test, ifTrue: l.ifTrue ^ v, else: l.else ^ v };
       if (op === '&&')
-        return { test: l.test, then: l.then && v, else: l.else && v };
+        return { test: l.test, ifTrue: l.ifTrue && v, else: l.else && v };
       if (op === '||')
-        return { test: l.test, then: l.then || v, else: l.else || v };
+        return { test: l.test, ifTrue: l.ifTrue || v, else: l.else || v };
     } else if ('test' in r && 'value' in l) {
       const v: any = l.value;
       if (op === '==')
-        return { test: r.test, then: v == r.then, else: v == r.else };
+        return { test: r.test, ifTrue: v == r.ifTrue, else: v == r.else };
       if (op === '===')
-        return { test: r.test, then: v === r.then, else: v === r.else };
+        return { test: r.test, ifTrue: v === r.ifTrue, else: v === r.else };
       if (op === '!=')
-        return { test: r.test, then: v != r.then, else: v != r.else };
+        return { test: r.test, ifTrue: v != r.ifTrue, else: v != r.else };
       if (op === '!==')
-        return { test: r.test, then: v !== r.then, else: v !== r.else };
+        return { test: r.test, ifTrue: v !== r.ifTrue, else: v !== r.else };
       if (op === '+')
-        return { test: r.test, then: v + r.then, else: v + r.else };
+        return { test: r.test, ifTrue: v + r.ifTrue, else: v + r.else };
       if (op === '-')
-        return { test: r.test, then: v - r.then, else: v - r.else };
+        return { test: r.test, ifTrue: v - r.ifTrue, else: v - r.else };
       if (op === '*')
-        return { test: r.test, then: v * r.then, else: v * r.else };
+        return { test: r.test, ifTrue: v * r.ifTrue, else: v * r.else };
       if (op === '/')
-        return { test: r.test, then: v / r.then, else: v / r.else };
+        return { test: r.test, ifTrue: v / r.ifTrue, else: v / r.else };
       if (op === '%')
-        return { test: r.test, then: v % r.then, else: v % r.else };
+        return { test: r.test, ifTrue: v % r.ifTrue, else: v % r.else };
       if (op === '<')
-        return { test: r.test, then: v < r.then, else: v < r.else };
+        return { test: r.test, ifTrue: v < r.ifTrue, else: v < r.else };
       if (op === '<=')
-        return { test: r.test, then: v <= r.then, else: v <= r.else };
+        return { test: r.test, ifTrue: v <= r.ifTrue, else: v <= r.else };
       if (op === '>')
-        return { test: r.test, then: v > r.then, else: v > r.else };
+        return { test: r.test, ifTrue: v > r.ifTrue, else: v > r.else };
       if (op === '>=')
-        return { test: r.test, then: v >= r.then, else: v >= r.else };
+        return { test: r.test, ifTrue: v >= r.ifTrue, else: v >= r.else };
       if (op === '|')
-        return { test: r.test, then: v | r.then, else: v | r.else };
+        return { test: r.test, ifTrue: v | r.ifTrue, else: v | r.else };
       if (op === '&')
-        return { test: r.test, then: v & r.then, else: v & r.else };
+        return { test: r.test, ifTrue: v & r.ifTrue, else: v & r.else };
       if (op === '^')
-        return { test: r.test, then: v ^ r.then, else: v ^ r.else };
+        return { test: r.test, ifTrue: v ^ r.ifTrue, else: v ^ r.else };
       if (op === '&&')
-        return { test: r.test, then: v && r.then, else: l && r.else };
+        return { test: r.test, ifTrue: v && r.ifTrue, else: l && r.else };
       if (op === '||')
-        return { test: r.test, then: v || r.then, else: l || r.else };
+        return { test: r.test, ifTrue: v || r.ifTrue, else: l || r.else };
     } else if ('value' in l && 'value' in r) {
       if (op === '==') return { value: l.value == r.value };
       if (op === '===') return { value: l.value === r.value };
@@ -280,7 +280,7 @@ const visitors: Record<
         if (predicate) return;
         predicate = x.test;
         argsElse = args.concat([]);
-        args.push(x.then);
+        args.push(x.ifTrue);
         argsElse.push(x.else);
       } else {
         args.push(x.value);
@@ -304,7 +304,7 @@ const visitors: Record<
       }
       const resultElse = await fn.apply(ctx, argsElse);
       if (result === UNKNOWN) return;
-      return { test: predicate, then: result, else: resultElse };
+      return { test: predicate, ifTrue: result, else: resultElse };
     } catch (e) {
       return;
     }
@@ -327,7 +327,7 @@ const visitors: Record<
 
     return {
       test: node.test,
-      then: thenValue.value === URL ? undefined : thenValue.value,
+      ifTrue: thenValue.value,
       else: elseValue.value,
     };
   },
@@ -444,7 +444,7 @@ const visitors: Record<
           try {
             return {
               test,
-              then: new URL(arg.then, parent.value),
+              ifTrue: new URL(arg.ifTrue, parent.value),
               else: new URL(arg.else, parent.value),
             };
           } catch {
@@ -454,7 +454,7 @@ const visitors: Record<
         try {
           return {
             test,
-            then: new URL(arg.then),
+            ifTrue: new URL(arg.ifTrue),
             else: new URL(arg.else),
           };
         } catch {
@@ -512,7 +512,7 @@ const visitors: Record<
       if ('value' in val) {
         val.value += node.quasis[i].value.cooked;
       } else {
-        val.then += node.quasis[i].value.cooked;
+        val.ifTrue += node.quasis[i].value.cooked;
         val.else += node.quasis[i].value.cooked;
       }
       let exprValue = await walk(node.expressions[i]);
@@ -527,7 +527,7 @@ const visitors: Record<
             val.wildcards = [...(val.wildcards || []), ...exprValue.wildcards];
         } else {
           if (exprValue.wildcards) return;
-          val.then += exprValue.value;
+          val.ifTrue += exprValue.value;
           val.else += exprValue.value;
         }
       } else if ('value' in val) {
@@ -537,7 +537,7 @@ const visitors: Record<
         }
         val = {
           test: exprValue.test,
-          then: val.value + exprValue.then,
+          ifTrue: val.value + exprValue.ifTrue,
           else: val.value + exprValue.else,
         };
       } else {
@@ -548,7 +548,7 @@ const visitors: Record<
     if ('value' in val) {
       val.value += node.quasis[i].value.cooked;
     } else {
-      val.then += node.quasis[i].value.cooked;
+      val.ifTrue += node.quasis[i].value.cooked;
       val.else += node.quasis[i].value.cooked;
     }
     return val;
@@ -575,13 +575,13 @@ const visitors: Record<
       if (node.operator === '!') return { value: !val.value };
     } else if ('test' in val && 'wildcards' in val === false) {
       if (node.operator === '+')
-        return { test: val.test, then: +val.then, else: +val.else };
+        return { test: val.test, ifTrue: +val.ifTrue, else: +val.else };
       if (node.operator === '-')
-        return { test: val.test, then: -val.then, else: -val.else };
+        return { test: val.test, ifTrue: -val.ifTrue, else: -val.else };
       if (node.operator === '~')
-        return { test: val.test, then: ~val.then, else: ~val.else };
+        return { test: val.test, ifTrue: ~val.ifTrue, else: ~val.else };
       if (node.operator === '!')
-        return { test: val.test, then: !val.then, else: !val.else };
+        return { test: val.test, ifTrue: !val.ifTrue, else: !val.else };
     }
     return undefined;
   },

--- a/src/utils/static-eval.ts
+++ b/src/utils/static-eval.ts
@@ -327,7 +327,7 @@ const visitors: Record<
 
     return {
       test: node.test,
-      then: thenValue.value,
+      then: thenValue.value === URL ? undefined : thenValue.value,
       else: elseValue.value,
     };
   },

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -8,7 +8,8 @@ export interface StaticValue {
 
 export interface ConditionalValue {
   test: string;
-  then: any;
+  // then is reserved for thenables
+  ifTrue: any;
   else: any;
 }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -8,7 +8,6 @@ export interface StaticValue {
 
 export interface ConditionalValue {
   test: string;
-  // then is reserved for thenables
   ifTrue: any;
   else: any;
 }

--- a/test/unit/url-error/input.js
+++ b/test/unit/url-error/input.js
@@ -1,0 +1,1 @@
+const URLParser = typeof window === 'undefined' ? URL : 'b';

--- a/test/unit/url-error/output.js
+++ b/test/unit/url-error/output.js
@@ -1,0 +1,4 @@
+[
+  "package.json", 
+  "test/unit/url-error/input.js"
+]


### PR DESCRIPTION
`nodeFileTrace` errors on `const URLParser = typeof window === 'undefined' ? URL : 'b'` with `TypeError: Class constructor URL cannot be invoked without 'new'`.

This is because this code:

```ts
async function ConditionalExpression() {
  return {
    test: 'foo',
    then: URL,
    else: 'bar',
  };
}
await ConditionalExpression();
```

calls `URL()` since `ConditionalExpression` is an async function returning a [thenable](https://masteringjs.io/tutorials/fundamentals/thenable).

Solution: rename all `.then` fields to `.ifTrue` since `then` is reserved for thenables.

Closes https://github.com/vercel/nft/pull/447