### PR TITLE
feat: support `module.createRequire`

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -1082,6 +1082,20 @@ export default async function analyze(
           if (returned) setKnownBinding(fnName.name, { value: BOUND_REQUIRE });
         }
       }
+      // Support module.createRequire
+      if (
+        node.type === 'CallExpression' &&
+        node.callee.type === 'MemberExpression' &&
+        node.callee.object.type === 'Identifier' &&
+        node.callee.object.name === 'module' &&
+        node.callee.property.type === 'Identifier' &&
+        node.callee.property.name === 'createRequire'
+      ) {
+        if (parent.type === 'VariableDeclarator') {
+          const requireName = parent.id.name;
+          setKnownBinding(requireName, { value: BOUND_REQUIRE });
+        }
+      }
     },
     async leave(_node, _parent) {
       const node: Node = _node as any;

--- a/test/unit/module-create-require/input.js
+++ b/test/unit/module-create-require/input.js
@@ -1,0 +1,4 @@
+import * as module from 'node:module';
+
+const req = module.createRequire(import.meta.url);
+const lib = req('./lib.node'); 

--- a/test/unit/module-create-require/lib.node
+++ b/test/unit/module-create-require/lib.node
@@ -1,0 +1,1 @@
+// Native module for testing 

--- a/test/unit/module-create-require/output.js
+++ b/test/unit/module-create-require/output.js
@@ -1,0 +1,5 @@
+[
+  "package.json",
+  "test/unit/module-create-require/input.js",
+  "test/unit/module-create-require/lib.node"
+]


### PR DESCRIPTION
## Description
Added support for tracing dependencies loaded via `module.createRequire`.


Fixes #430