### PR TITLE
fix: require node 18 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
   },
   "packageManager": "npm@10.2.5",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
As discussed [here](https://github.com/vercel/nft/issues/457#issuecomment-2568065889), node 16 support was already dropped in 0.26.0, but `package.json#engines#node` was not updated.

Closes https://github.com/vercel/nft/issues/457.