### PR TITLE
chore(ci): fix corepack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
   test:
     name: Test on node ${{ matrix.node }} and ${{ matrix.os }}
     timeout-minutes: 20
+    env:
+      COREPACK_DEFAULT_TO_LATEST: '0'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fix CI due to corepack issue:

- https://github.com/nodejs/corepack/issues/612

The solution is to set `COREPACK_DEFAULT_TO_LATEST=0` as suggested here:

- https://github.com/nodejs/corepack/issues/625#issuecomment-2630065183

This works since we pin the version of pnpm in package.json and don't rely on corepack fetching the latest pnpm version.