### PR TITLE
fix: upgrade to glob 10

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+<!--
+PRs prefixed with `chore:` will skip creating a changelog entry and release.
+PRs prefixed with `fix:` will do a patch release.
+PRs prefixed with `feat:` will do a minor release.
+-->


### PR DESCRIPTION
The actual PR for glob upgrade is https://github.com/vercel/nft/pull/505

Adding these notes as I think it's not the first time I've made this mistake and there's not really a way for contributors to know at the moment