### PR TITLE
fix: add special case for `ffmpeg-static`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "express": "^4.21.2",
         "fast-glob": "^3.1.1",
         "fetch-h2": "^3.0.2",
+        "ffmpeg-static": "^5.2.0",
         "firebase": "^11.2.0",
         "firebase-admin": "^13.2.0",
         "fluent-ffmpeg": "^2.1.2",
@@ -2400,6 +2401,36 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@derhuerst/http-basic": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@derhuerst/http-basic/-/http-basic-8.2.4.tgz",
+      "integrity": "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==",
+      "dev": true,
+      "dependencies": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^2.0.0",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@derhuerst/http-basic/node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "dev": true,
+      "engines": [
+        "node >= 6.0"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -15468,6 +15499,15 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -17644,6 +17684,31 @@
         "readable-stream": "3"
       }
     },
+    "node_modules/ffmpeg-static": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.2.0.tgz",
+      "integrity": "sha512-WrM7kLW+do9HLr+H6tk7LzQ7kPqbAgLjdzNE32+u3Ff11gXt9Kkkd2nusGFrlWMIe+XaA97t+I8JS7sZIrvRgA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@derhuerst/http-basic": "^8.2.0",
+        "env-paths": "^2.2.0",
+        "https-proxy-agent": "^5.0.0",
+        "progress": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/ffmpeg-static/node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/file-contents": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/file-contents/-/file-contents-0.3.2.tgz",
@@ -19726,6 +19791,21 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^10.0.3"
+      }
+    },
+    "node_modules/http-response-object/node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "dev": true
     },
     "node_modules/http-signature": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "express": "^4.21.2",
     "fast-glob": "^3.1.1",
     "fetch-h2": "^3.0.2",
+    "ffmpeg-static": "^5.2.0",
     "firebase": "^11.2.0",
     "firebase-admin": "^13.2.0",
     "fluent-ffmpeg": "^2.1.2",

--- a/src/utils/special-cases.ts
+++ b/src/utils/special-cases.ts
@@ -45,6 +45,12 @@ const specialCases: Record<string, (o: SpecialCaseOpts) => void> = {
       }
     }
   },
+  'ffmpeg-static'({ id, emitAsset }) {
+    if (id.endsWith('ffmpeg-static/index.js')) {
+      const bin = require(id);
+      emitAsset(bin);
+    }
+  },
   'google-gax'({ id, ast, emitAssetDirectory }) {
     if (id.endsWith('google-gax/build/src/grpc.js')) {
       // const googleProtoFilesDir = path.normalize(google_proto_files_1.getProtoPath('..'));

--- a/test/integration/ffmpeg-static.js
+++ b/test/integration/ffmpeg-static.js
@@ -1,0 +1,9 @@
+const { execFile } = require('child_process');
+const ffmpeg = require('ffmpeg-static');
+
+execFile(ffmpeg, ['-version'], (error, _stdout, stderr) => {
+  if (error || stderr) {
+    console.error("Error executing ffmpeg:", error || stderr);
+    process.exit(1);
+  }
+});


### PR DESCRIPTION
The `ffmpeg-static` pkg has a lot of dynamic code, especially for install, but we know the public api is to always return the path to the binary. So we can use that in a special case to always emit that binary.