### PR TITLE
fix: evaluate nested export conditions when resolving a module-sync fallback

### DIFF
--- a/src/resolve-dependency.ts
+++ b/src/resolve-dependency.ts
@@ -254,7 +254,11 @@ async function resolveExportsImports(
       ) {
         const fallbackCondition =
           'require' in exportsForSubpath ? 'require' : 'default';
-        const fallbackTarget = exportsForSubpath[fallbackCondition];
+        const fallbackTarget = getExportsTarget(
+          exportsForSubpath[fallbackCondition],
+          job.conditions,
+          cjsResolve,
+        );
         if (
           typeof fallbackTarget === 'string' &&
           fallbackTarget.startsWith('./')

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -28,6 +28,7 @@ const skipOnMac = [];
 const skipOnNode20AndBelow = [
   'module-sync-condition-es',
   'module-sync-condition-cjs',
+  'module-sync-condition-es-nested',
   'imports-module-sync',
   'imports-module-sync-cjs',
   'self-reference-module-sync',

--- a/test/unit/module-sync-condition-es-nested/fallback.js
+++ b/test/unit/module-sync-condition-es-nested/fallback.js
@@ -1,0 +1,1 @@
+export const test = 'fallback version'; 

--- a/test/unit/module-sync-condition-es-nested/import.js
+++ b/test/unit/module-sync-condition-es-nested/import.js
@@ -1,0 +1,1 @@
+export const test = 'import version'; 

--- a/test/unit/module-sync-condition-es-nested/input.js
+++ b/test/unit/module-sync-condition-es-nested/input.js
@@ -1,0 +1,2 @@
+import { test } from 'test-pkg-sync-es';
+console.log(test); 

--- a/test/unit/module-sync-condition-es-nested/module-sync.js
+++ b/test/unit/module-sync-condition-es-nested/module-sync.js
@@ -1,0 +1,1 @@
+export const test = 'module-sync version'; 

--- a/test/unit/module-sync-condition-es-nested/output.js
+++ b/test/unit/module-sync-condition-es-nested/output.js
@@ -1,0 +1,6 @@
+[
+  "test/unit/module-sync-condition-es-nested/fallback.js",
+  "test/unit/module-sync-condition-es-nested/input.js",
+  "test/unit/module-sync-condition-es-nested/module-sync.js",
+  "test/unit/module-sync-condition-es-nested/package.json"
+]

--- a/test/unit/module-sync-condition-es-nested/package.json
+++ b/test/unit/module-sync-condition-es-nested/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "test-pkg-sync-es",
+  "type": "module",
+  "exports": {
+    ".": {
+      "module-sync": {
+        "default": "./module-sync.js"
+      },
+      "import": {
+        "default": "./import.js"
+      },
+      "default": {
+        "default": "./fallback.js"
+      }
+    }
+  }
+}


### PR DESCRIPTION
The code (added [here](https://github.com/vercel/nft/pull/550)) was previously only adding the fallback when the condition was a string, but wasn't handling `{`"default": {"default": "./fallback.js"}}`, as is used in [this package](https://www.npmjs.com/package/@mjackson/node-fetch-server/v/0.2.0?activeTab=code)