### PR TITLE
feat: handle external packages in imports field

### DIFF
--- a/src/resolve-dependency.ts
+++ b/src/resolve-dependency.ts
@@ -271,6 +271,10 @@ async function resolveExportsImports(
       }
 
       return await validateAndResolvePaths(paths, parent, job, cjsResolve);
+    } else if (isImports && typeof target === 'string') {
+      // The imports field additionally allows external dependencies as well
+      const resolved = await resolveDependency(target, parent, job, cjsResolve);
+      return Array.isArray(resolved) ? resolved : [resolved];
     }
   }
   for (const match of Object.keys(matchObj).sort(

--- a/test/unit/imports/.gitignore
+++ b/test/unit/imports/.gitignore
@@ -1,0 +1,2 @@
+# include node_modules for testing
+!node_modules 

--- a/test/unit/imports/input.js
+++ b/test/unit/imports/input.js
@@ -1,2 +1,5 @@
 import { x } from '#x';
 console.log(x);
+
+import { pkg } from '#pkg';
+console.log(pkg);

--- a/test/unit/imports/node_modules/pkg/index.js
+++ b/test/unit/imports/node_modules/pkg/index.js
@@ -1,0 +1,1 @@
+export const pkg = 'pkg';

--- a/test/unit/imports/output.js
+++ b/test/unit/imports/output.js
@@ -1,5 +1,6 @@
 [
   "test/unit/imports/input.js",
   "test/unit/imports/node.js",
+  "test/unit/imports/node_modules/pkg/index.js",
   "test/unit/imports/package.json"
 ]

--- a/test/unit/imports/package.json
+++ b/test/unit/imports/package.json
@@ -7,6 +7,7 @@
       "default": {
         "node": "./node.js"
       }
-    }
+    },
+    "#pkg": "pkg"
   }
 }


### PR DESCRIPTION
https://nodejs.org/api/packages.html#subpath-exports:

> All target paths in the ["exports"](https://nodejs.org/api/packages.html#exports) map (the values associated with export keys) must be relative URL strings starting with `./`

but

>Unlike the "exports" field, the "imports" field permits mapping to external packages.
>The resolution rules for the imports field are otherwise analogous to the exports field.
