### PR TITLE
fix: await file IO before releasing concurrency semaphore

### DIFF
--- a/src/fs.ts
+++ b/src/fs.ts
@@ -112,7 +112,7 @@ export class CachedFileSystem {
     await this.fileIOQueue.acquire();
 
     try {
-      return fileIO.call(this, path);
+      return await fileIO.call(this, path);
     } finally {
       this.fileIOQueue.release();
     }

--- a/test/fs-concurrency.test.js
+++ b/test/fs-concurrency.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const pendingReads = [];
+
+jest.mock('graceful-fs', () => {
+  const original = jest.requireActual('graceful-fs');
+  return {
+    ...original,
+    promises: {
+      ...original.promises,
+      readFile: jest.fn(
+        () =>
+          new Promise((resolve) => {
+            pendingReads.push(() => resolve(Buffer.from('content')));
+          }),
+      ),
+    },
+  };
+});
+
+const gracefulFS = require('graceful-fs');
+const { CachedFileSystem } = require('../out/fs');
+
+const flushMicrotasks = () => new Promise((r) => setImmediate(r));
+
+describe('CachedFileSystem concurrency limit', () => {
+  beforeEach(() => {
+    pendingReads.length = 0;
+    gracefulFS.promises.readFile.mockClear();
+  });
+
+  it('serializes file IO when fileIOConcurrency is 1', async () => {
+    const fileSystem = new CachedFileSystem({ fileIOConcurrency: 1 });
+
+    const a = fileSystem.readFile('/a.txt');
+    const b = fileSystem.readFile('/b.txt');
+
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(gracefulFS.promises.readFile).toHaveBeenCalledTimes(1);
+
+    pendingReads[0]();
+    await a;
+    await flushMicrotasks();
+
+    expect(gracefulFS.promises.readFile).toHaveBeenCalledTimes(2);
+
+    pendingReads[1]();
+    await b;
+  });
+});


### PR DESCRIPTION
## Summary

`CachedFileSystem.executeFileIO` returned the inner promise without `await`, so the `try/finally` released the `fileIOQueue` semaphore the moment the IO was kicked off rather than when it resolved. The intended `fileIOConcurrency` cap (default `1024`) was effectively bypassed: every caller acquired the slot, fired off the IO, immediately released, and the next caller acquired — so all reads ran fully concurrently regardless of the configured limit.

```diff
   private async executeFileIO<Return>(
     path: string,
     fileIO: (path: string) => Promise<Return>,
   ): Promise<Return> {
     await this.fileIOQueue.acquire();
     try {
-      return fileIO.call(this, path);
+      return await fileIO.call(this, path);
     } finally {
       this.fileIOQueue.release();
     }
   }
```

Adding `await` holds the slot until the underlying `fs.readFile` / `fs.stat` / `fs.readlink` actually completes, restoring the back-pressure originally introduced in #301.

## Test plan

- [x] New `test/fs-concurrency.test.js` regression test: with `fileIOConcurrency: 1`, kicks off two `readFile` calls on different paths and asserts only the first hits `graceful-fs.promises.readFile` until it resolves; the second proceeds afterward.
- [x] Verified the test **fails** on the pre-fix code (`Expected number of calls: 1, Received: 2`) and **passes** after the one-line fix.
- [x] All 299 existing unit tests still pass (`npx jest test/unit.test.js`).
- [x] `npx prettier --check src/fs.ts test/fs-concurrency.test.js` clean.
