### PR TITLE
feat: module-sync fallback should use import for ESM

### DIFF
--- a/src/resolve-dependency.ts
+++ b/src/resolve-dependency.ts
@@ -253,7 +253,11 @@ async function resolveExportsImports(
         getNodeMajorVersion() >= 22
       ) {
         const fallbackCondition =
-          'require' in exportsForSubpath ? 'require' : 'default';
+          cjsResolve && 'require' in exportsForSubpath
+            ? 'require'
+            : !cjsResolve && 'import' in exportsForSubpath
+              ? 'import'
+              : 'default';
         const fallbackTarget = getExportsTarget(
           exportsForSubpath[fallbackCondition],
           job.conditions,

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -28,6 +28,7 @@ const skipOnMac = [];
 const skipOnNode20AndBelow = [
   'module-sync-condition-es',
   'module-sync-condition-cjs',
+  'module-sync-condition-es-default',
   'module-sync-condition-es-nested',
   'imports-module-sync',
   'imports-module-sync-cjs',

--- a/test/unit/imports-module-sync/output.js
+++ b/test/unit/imports-module-sync/output.js
@@ -1,6 +1,6 @@
 [
   "test/unit/imports-module-sync/input.js",
-  "test/unit/imports-module-sync/internal-default.js",
+  "test/unit/imports-module-sync/internal-import.js",
   "test/unit/imports-module-sync/internal-sync.js",
   "test/unit/imports-module-sync/package.json"
 ]

--- a/test/unit/module-sync-condition-es-default/fallback.js
+++ b/test/unit/module-sync-condition-es-default/fallback.js
@@ -1,0 +1,1 @@
+export const test = 'fallback version'; 

--- a/test/unit/module-sync-condition-es-default/input.js
+++ b/test/unit/module-sync-condition-es-default/input.js
@@ -1,0 +1,2 @@
+import { test } from 'test-pkg-sync-es';
+console.log(test); 

--- a/test/unit/module-sync-condition-es-default/module-sync.js
+++ b/test/unit/module-sync-condition-es-default/module-sync.js
@@ -1,0 +1,1 @@
+export const test = 'module-sync version'; 

--- a/test/unit/module-sync-condition-es-default/output.js
+++ b/test/unit/module-sync-condition-es-default/output.js
@@ -1,0 +1,6 @@
+[
+  "test/unit/module-sync-condition-es-default/fallback.js",
+  "test/unit/module-sync-condition-es-default/input.js",
+  "test/unit/module-sync-condition-es-default/module-sync.js",
+  "test/unit/module-sync-condition-es-default/package.json"
+]

--- a/test/unit/module-sync-condition-es-default/package.json
+++ b/test/unit/module-sync-condition-es-default/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test-pkg-sync-es",
+  "type": "module", 
+  "exports": {
+    ".": {
+      "module-sync": "./module-sync.js",
+      "require": "./require.js",
+      "default": "./fallback.js"
+    }
+  }
+} 

--- a/test/unit/module-sync-condition-es-default/require.js
+++ b/test/unit/module-sync-condition-es-default/require.js
@@ -1,0 +1,1 @@
+export const test = 'import version'; 

--- a/test/unit/module-sync-condition-es-nested/output.js
+++ b/test/unit/module-sync-condition-es-nested/output.js
@@ -1,5 +1,5 @@
 [
-  "test/unit/module-sync-condition-es-nested/fallback.js",
+  "test/unit/module-sync-condition-es-nested/import.js",
   "test/unit/module-sync-condition-es-nested/input.js",
   "test/unit/module-sync-condition-es-nested/module-sync.js",
   "test/unit/module-sync-condition-es-nested/package.json"

--- a/test/unit/module-sync-condition-es/output.js
+++ b/test/unit/module-sync-condition-es/output.js
@@ -1,5 +1,5 @@
 [
-  "test/unit/module-sync-condition-es/fallback.js",
+  "test/unit/module-sync-condition-es/import.js",
   "test/unit/module-sync-condition-es/input.js",
   "test/unit/module-sync-condition-es/module-sync.js",
   "test/unit/module-sync-condition-es/package.json"

--- a/test/unit/self-reference-module-sync/output.js
+++ b/test/unit/self-reference-module-sync/output.js
@@ -1,5 +1,5 @@
 [
-  "test/unit/self-reference-module-sync/default.js",
+  "test/unit/self-reference-module-sync/import.js",
   "test/unit/self-reference-module-sync/input.js",
   "test/unit/self-reference-module-sync/module-sync.js",
   "test/unit/self-reference-module-sync/package.json"


### PR DESCRIPTION
<!--
PRs prefixed with `chore:` will skip creating a changelog entry and release.
PRs prefixed with `fix:` will do a patch release.
PRs prefixed with `feat:` will do a minor release.
-->

Updates module-sync fallback tracing so ESM imports include the import fallback rather than default when module-sync is selected.

Tested with the existing module-sync unit coverage in this branch.

Made with [Cursor](https://cursor.com)