### PR TITLE
feat: refactor ffmpeg-static special case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/**/dist
 test/**/actual.js
 yarn.lock
 package-lock.json
+ffmpeg-version-diff

--- a/src/utils/special-cases.ts
+++ b/src/utils/special-cases.ts
@@ -1,4 +1,5 @@
 import { resolve, dirname, relative } from 'path';
+import { existsSync } from 'fs';
 import resolveDependency from '../resolve-dependency';
 import { getPackageName } from './get-package-base';
 import { readFileSync } from 'graceful-fs';
@@ -47,8 +48,15 @@ const specialCases: Record<string, (o: SpecialCaseOpts) => void> = {
   },
   'ffmpeg-static'({ id, emitAsset }) {
     if (id.endsWith('ffmpeg-static/index.js')) {
-      const bin = require(id);
-      emitAsset(bin);
+      const dir = dirname(id);
+      const ext = process.platform === 'win32' ? '.exe' : '';
+      const binaryPath = [
+        /*1.0.0 - 3.0.0*/ `${dir}/ffmpeg${ext}`,
+        /*4.0.0 - 5.3.0*/ `${dir}/bin/${process.platform}/${process.arch}/ffmpeg${ext}`,
+      ].find((file) => existsSync(file));
+      if (binaryPath) {
+        emitAsset(binaryPath);
+      }
     }
   },
   'google-gax'({ id, ast, emitAssetDirectory }) {

--- a/src/utils/special-cases.ts
+++ b/src/utils/special-cases.ts
@@ -51,8 +51,8 @@ const specialCases: Record<string, (o: SpecialCaseOpts) => void> = {
       const dir = dirname(id);
       const ext = process.platform === 'win32' ? '.exe' : '';
       const binaryPath = [
-        /*1.0.0 - 3.0.0*/ `${dir}/ffmpeg${ext}`,
-        /*4.0.0 - 5.3.0*/ `${dir}/bin/${process.platform}/${process.arch}/ffmpeg${ext}`,
+        resolve(dir, `ffmpeg${ext}`),
+        resolve(dir, 'bin', process.platform, process.arch, `ffmpeg${ext}`),
       ].find((file) => existsSync(file));
       if (binaryPath) {
         emitAsset(binaryPath);


### PR DESCRIPTION
Previously, this code would do a dynamic require but now it does static analysis on the possible output files.

I had a clanker go through all possible outputs from all versions to come up with this list.

Then I simplified it into the two fs calls here.

<img width="777" height="227" alt="image" src="https://github.com/user-attachments/assets/cb0ba5ab-1072-451d-a053-5c6017338320" />
