### PR TITLE
chore: pr lint title permission

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
+permissions:
+  pull-requests: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This action doesnt need to read the contents of the repo, it only needs access to the PR in order to validate the title. 

So this PR removes all permissions besides reading the PR metadata.

- Closes #579 