### PR TITLE
feat: remove badge from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,5 @@
 # Node File Trace
 
-[![CI Status](https://github.com/vercel/nft/actions/workflows/ci.yml/badge.svg)](https://github.com/vercel/nft/actions/workflows/ci.yml)
-
 Used to determine exactly which files (including `node_modules`) are necessary for the application runtime.
 
 This is similar to [@vercel/ncc](https://npmjs.com/package/@vercel/ncc) except there is no bundling performed and therefore no reliance on webpack. This achieves the same tree-shaking benefits without moving any assets or binaries.


### PR DESCRIPTION
Removed CI status badge from the README.

I'm calling this `feat:` since previous publishes have not gone through yet so I want to make sure it publishes as semver minor now that we setup trusted publishing.