### PR TITLE
fix: publish using node@24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,4 +79,5 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.node == 24 && github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COREPACK_ENABLE_STRICT: '0'
         run: pnpm --dir publish install --ignore-workspace --frozen-lockfile && ./publish/node_modules/.bin/semantic-release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,12 @@ jobs:
         ports:
           - 6379:6379
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           # we lock to 3.11 for a distutils requirement for node-gyp
           python-version: '3.11'
@@ -76,7 +76,7 @@ jobs:
           BULL_REDIS_CONNECTION: ${{ (matrix.os == 'ubuntu-latest') && 'redis://127.0.0.1:6379/0' || '' }}
         run: pnpm ${{ (matrix.os == 'ubuntu-latest') && 'test-verbose' || 'test' }}
       - name: Maybe Release
-        if: matrix.os == 'ubuntu-latest' && matrix.node == 22 && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: matrix.os == 'ubuntu-latest' && matrix.node == 24 && github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm --dir publish install --ignore-workspace --frozen-lockfile && ./publish/node_modules/.bin/semantic-release

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "./out/index.js",
   "types": "./out/index.d.ts",
   "bin": {
-    "nft": "./out/cli.js"
+    "nft": "out/cli.js"
   },
   "files": [
     "out"


### PR DESCRIPTION
npm is outdated and doesn't support trusted publishing so we need to use a newer node version to publish which implicily updates npm

(also we don't want corepack strict check to block npm)