### PR TITLE
chore(ci): disable phantomjs-prebuilt postinstall that breaks CI installs

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,11 @@ allowBuilds:
   msgpackr-extract: false
   nice-napi: false
   oracledb: false
-  phantomjs-prebuilt: true
+  # phantomjs-prebuilt (deprecated) downloads and extracts a binary from GitHub
+  # releases in its postinstall, which fails to extract on macOS/Windows and
+  # breaks CI. That postinstall only generates lib/location.js, which the trace
+  # test does not need. Skip the build so installs are reliable everywhere.
+  phantomjs-prebuilt: false
   protobufjs: false
   sharp: false
   unix-dgram: false

--- a/test/unit/phantomjs-prebuilt/output.js
+++ b/test/unit/phantomjs-prebuilt/output.js
@@ -2,7 +2,6 @@
   "node_modules/es6-promise/dist/es6-promise.js",
   "node_modules/es6-promise/package.json",
   "node_modules/phantomjs-prebuilt/bin/phantomjs",
-  "node_modules/phantomjs-prebuilt/lib/location.js",
   "node_modules/phantomjs-prebuilt/lib/phantomjs.js",
   "node_modules/phantomjs-prebuilt/package.json",
   "package.json",


### PR DESCRIPTION
## What

Disable the `phantomjs-prebuilt` postinstall build (pnpm `allowBuilds: false`) and drop the install-generated `lib/location.js` from the expected trace fixture.

## Why

`phantomjs-prebuilt` is deprecated. Its postinstall downloads a 16MB binary from GitHub releases and extracts it to generate `lib/location.js`. The download succeeds, but the **zip extraction consistently fails on macOS/Windows**:

```
node_modules/phantomjs-prebuilt install: Received 16746K total.
node_modules/phantomjs-prebuilt install: Extracting zip contents
node_modules/phantomjs-prebuilt install: Install exited unexpectedly
 ELIFECYCLE  Command failed with exit code 1.
```

This fails `pnpm install` and breaks CI for any PR that touches dependencies (e.g. #596), and re-running doesn't help.

The `test/unit/phantomjs-prebuilt` fixture only exercises nft's special case that emits the `bin/` directory — `lib/location.js` is just an install artifact, not part of the behavior under test. Skipping the build makes installs reliable on every OS while preserving the meaningful test coverage.

## Verification

- Removed `lib/location.js` locally and confirmed the phantomjs trace test passes against the updated fixture.
- Full CI matrix is green, including the Node 24 macOS/Windows jobs that previously failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)