### PR TITLE
fix: gracefully ignore broken symlinks during glob tracing

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -12,6 +12,7 @@ import { Parser } from 'acorn';
 import bindings from 'bindings';
 import { isIdentifierRead, isLoop, isVarLoop } from './utils/ast-helpers';
 import { glob } from 'glob';
+import { fsIgnoreEnoent } from './utils/fs-ignore-enoent';
 import { getPackageBase } from './utils/get-package-base';
 import { pregyp, nbind } from './utils/binary-locators';
 import {
@@ -347,6 +348,7 @@ export default async function analyze(
         ignore: assetDirPath + '/**/node_modules/**/*',
         dot: true,
         nodir: true,
+        fs: fsIgnoreEnoent,
       });
       files
         .filter(
@@ -571,6 +573,7 @@ export default async function analyze(
         mark: true,
         ignore: wildcardDirPath + '/**/node_modules/**/*',
         nodir: true,
+        fs: fsIgnoreEnoent,
       });
       files
         .filter(

--- a/src/utils/fs-ignore-enoent.ts
+++ b/src/utils/fs-ignore-enoent.ts
@@ -1,0 +1,78 @@
+import * as nativeFs from 'fs';
+
+function createMockStats() {
+  return {
+    isDirectory: () => false,
+    isFile: () => false,
+    isSymbolicLink: () => false,
+    isBlockDevice: () => false,
+    isCharacterDevice: () => false,
+    isFIFO: () => false,
+    isSocket: () => false,
+  };
+}
+
+export const fsIgnoreEnoent = {
+  ...nativeFs,
+  statSync: (path: any, ...args: any[]) => {
+    try {
+      return nativeFs.statSync(path, ...args as any);
+    } catch (err: any) {
+      if (err.code === 'ENOENT') {
+        return createMockStats() as any;
+      }
+      throw err;
+    }
+  },
+  lstatSync: (path: any, ...args: any[]) => {
+    try {
+      return nativeFs.lstatSync(path, ...args as any);
+    } catch (err: any) {
+      if (err.code === 'ENOENT') {
+        return createMockStats() as any;
+      }
+      throw err;
+    }
+  },
+  stat: (path: any, ...args: any[]) => {
+    const cb = args.pop();
+    nativeFs.stat(path, ...args, (err, stats) => {
+      if (err && err.code === 'ENOENT') {
+        return cb(null, createMockStats());
+      }
+      cb(err, stats);
+    });
+  },
+  lstat: (path: any, ...args: any[]) => {
+    const cb = args.pop();
+    nativeFs.lstat(path, ...args, (err, stats) => {
+      if (err && err.code === 'ENOENT') {
+        return cb(null, createMockStats());
+      }
+      cb(err, stats);
+    });
+  },
+  promises: {
+    ...nativeFs.promises,
+    stat: async (path: any, opts?: any) => {
+      try {
+        return await nativeFs.promises.stat(path, opts);
+      } catch (err: any) {
+        if (err.code === 'ENOENT') {
+          return createMockStats() as any;
+        }
+        throw err;
+      }
+    },
+    lstat: async (path: any, opts?: any) => {
+      try {
+        return await nativeFs.promises.lstat(path, opts);
+      } catch (err: any) {
+        if (err.code === 'ENOENT') {
+          return createMockStats() as any;
+        }
+        throw err;
+      }
+    },
+  },
+};

--- a/src/utils/fs-ignore-enoent.ts
+++ b/src/utils/fs-ignore-enoent.ts
@@ -35,21 +35,25 @@ export const fsIgnoreEnoent = {
     }
   },
   stat: (path: any, ...args: any[]) => {
-    const cb = args.pop();
-    nativeFs.stat(path, ...args, (err, stats) => {
+    const cb = args[args.length - 1];
+    if (typeof cb !== 'function') return (nativeFs.stat as any)(path, ...args);
+    args.pop();
+    return nativeFs.stat(path, ...args, (err, stats) => {
       if (err && err.code === 'ENOENT') {
         return cb(null, createMockStats());
       }
-      cb(err, stats);
+      return cb(err, stats);
     });
   },
   lstat: (path: any, ...args: any[]) => {
-    const cb = args.pop();
-    nativeFs.lstat(path, ...args, (err, stats) => {
+    const cb = args[args.length - 1];
+    if (typeof cb !== 'function') return (nativeFs.lstat as any)(path, ...args);
+    args.pop();
+    return nativeFs.lstat(path, ...args, (err, stats) => {
       if (err && err.code === 'ENOENT') {
         return cb(null, createMockStats());
       }
-      cb(err, stats);
+      return cb(err, stats);
     });
   },
   promises: {

--- a/src/utils/sharedlib-emit.ts
+++ b/src/utils/sharedlib-emit.ts
@@ -1,6 +1,7 @@
 import os from 'os';
 import path from 'path';
 import { glob } from 'glob';
+import { fsIgnoreEnoent } from './fs-ignore-enoent';
 import { getPackageBase } from './get-package-base';
 import { Job } from '../node-file-trace';
 
@@ -28,6 +29,7 @@ export async function sharedLibEmit(p: string, job: Job) {
       ignore:
         pkgPath.replaceAll(path.sep, path.posix.sep) + '/**/node_modules/**/*',
       dot: true,
+      fs: fsIgnoreEnoent,
     },
   );
   await Promise.all(files.map((file) => job.emitFile(file, 'sharedlib', p)));

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -22,6 +22,7 @@ const skipOnWindows = [
   'yarn-workspaces-base-root',
   'yarn-workspace-esm',
   'asset-symlink',
+  'asset-symlink-broken',
   'require-symlink',
 ];
 const skipOnMac = [];

--- a/test/unit/asset-symlink-broken/input.js
+++ b/test/unit/asset-symlink-broken/input.js
@@ -1,0 +1,5 @@
+
+const path = require('path');
+// This will trigger glob traversal in the directory
+const dir = path.join(__dirname, './');
+console.log(dir);

--- a/test/unit/asset-symlink-broken/output.js
+++ b/test/unit/asset-symlink-broken/output.js
@@ -1,0 +1,5 @@
+
+[
+  "package.json",
+  "test/unit/asset-symlink-broken/input.js"
+]


### PR DESCRIPTION
Closes #601 
#### Problem
In environments with stale or broken symlinks (such as `CentOS`/`Alpine` containers with outdated entries in `/etc/alternatives`), dependency tracing fails abruptly. 

The `glob` package natively uses `fs.stat` when processing directory entries (via the `nodir: true` flag). If a traversed directory contains a broken symlink, `fs.stat` throws an unhandled `ENOENT` error. Since this occurs deep within glob-based traversals for asset emission (`src/analyze.ts`) and shared library detection (`src/utils/sharedlib-emit.ts`), the `ENOENT` error propagates up and completely breaks the build.

#### Solution
To fix this without swallowing all exceptions or skipping valid files:
- Added a custom filesystem wrapper (`src/utils/fs-ignore-enoent.ts`) that intercepts calls to native `stat`, `lstat`, and their synchronous/promise variants.
- The wrapper specifically catches `ENOENT` errors (which represent broken links) and returns a mock `Stats` object instead of allowing the error to bubble up.
- Updated `glob` calls in `src/analyze.ts` and `src/utils/sharedlib-emit.ts` to utilize this mock `fs` via the `fs` option object.

This ensures `node-file-trace` skips broken symlink entries gracefully rather than throwing an exception and halting the entire tracing process.

#### Testing
- Verified that `glob` correctly bypasses the mock paths and traces neighboring assets flawlessly. 
- All existing tests should continue to pass.