### PR TITLE
feat: resolve package import wildcard trailers

### DIFF
--- a/src/resolve-dependency.ts
+++ b/src/resolve-dependency.ts
@@ -193,6 +193,42 @@ function getExportsTarget(
   return undefined;
 }
 
+function patternKeyCompare(a: string, b: string): number {
+  const aPatternIndex = a.indexOf('*');
+  const bPatternIndex = b.indexOf('*');
+
+  const aBaseLength = aPatternIndex === -1 ? a.length : aPatternIndex + 1;
+  const bBaseLength = bPatternIndex === -1 ? b.length : bPatternIndex + 1;
+
+  if (aBaseLength > bBaseLength) return -1;
+  if (bBaseLength > aBaseLength) return 1;
+  if (aPatternIndex === -1) return 1;
+  if (bPatternIndex === -1) return -1;
+  if (a.length > b.length) return -1;
+  if (b.length > a.length) return 1;
+  return 0;
+}
+
+function getPatternMatch(pattern: string, subpath: string): string | undefined {
+  const patternIndex = pattern.indexOf('*');
+  if (patternIndex === -1 || pattern.lastIndexOf('*') !== patternIndex) {
+    return undefined;
+  }
+
+  const patternBase = pattern.slice(0, patternIndex);
+  if (!subpath.startsWith(patternBase)) return undefined;
+
+  const patternTrailer = pattern.slice(patternIndex + 1);
+  if (
+    subpath.length < pattern.length ||
+    (patternTrailer && !subpath.endsWith(patternTrailer))
+  ) {
+    return undefined;
+  }
+
+  return subpath.slice(patternIndex, subpath.length - patternTrailer.length);
+}
+
 function addExportsTargetPath(
   paths: string[],
   pkgPath: string,
@@ -308,10 +344,9 @@ async function resolveExportsImports(
       return Array.isArray(resolved) ? resolved : [resolved];
     }
   }
-  for (const match of Object.keys(matchObj).sort(
-    (a, b) => b.length - a.length,
-  )) {
-    if (match.endsWith('*') && subpath.startsWith(match.slice(0, -1))) {
+  for (const match of Object.keys(matchObj).sort(patternKeyCompare)) {
+    const wildcardReplacement = getPatternMatch(match, subpath);
+    if (wildcardReplacement !== undefined) {
       const target = getExportsTarget(
         matchObj[match],
         job.conditions,
@@ -320,10 +355,8 @@ async function resolveExportsImports(
       );
       if (typeof target === 'string' && target.startsWith('./')) {
         const resolvedPath =
-          pkgPath +
-          target.slice(1).replace(/\*/g, subpath.slice(match.length - 1));
+          pkgPath + target.slice(1).replace(/\*/g, wildcardReplacement);
         const paths = [resolvedPath];
-        const wildcardReplacement = subpath.slice(match.length - 1);
 
         const exportsForSubpath = matchObj[match];
         if (

--- a/test/unit/imports-wildcard/dist/internal/marker.js
+++ b/test/unit/imports-wildcard/dist/internal/marker.js
@@ -1,0 +1,1 @@
+export const marker = 'resolved';

--- a/test/unit/imports-wildcard/input.js
+++ b/test/unit/imports-wildcard/input.js
@@ -1,0 +1,2 @@
+import { marker } from '#internal/marker.js';
+console.log(marker);

--- a/test/unit/imports-wildcard/output.js
+++ b/test/unit/imports-wildcard/output.js
@@ -1,0 +1,5 @@
+[
+  "test/unit/imports-wildcard/dist/internal/marker.js",
+  "test/unit/imports-wildcard/input.js",
+  "test/unit/imports-wildcard/package.json"
+]

--- a/test/unit/imports-wildcard/package.json
+++ b/test/unit/imports-wildcard/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "imports-wildcard",
+  "type": "module",
+  "imports": {
+    "#*.js": "./dist/*.js"
+  }
+}


### PR DESCRIPTION
## Summary

- resolve `package.json` import/export wildcard patterns that include a trailer, such as `#*.js`
- match both the pattern prefix and trailer before substituting the captured wildcard
- use Node-compatible pattern precedence and reject patterns containing multiple wildcards
- add an `imports-wildcard` trace fixture covering `#internal/marker.js` mapped through `#*.js`

## Context

NFT previously recognized wildcard keys only when they ended in `*`. A valid import map such as:

```json
{
  "imports": {
    "#*.js": "./dist/*.js"
  }
}
```

therefore failed to resolve `#internal/marker.js`. Consumers such as Nitro/nf3 would trace the package entry point but omit the internal target, producing an incomplete deployment artifact that failed at runtime with `ERR_MODULE_NOT_FOUND`.

Related reproduction and downstream workaround:

- https://github.com/cmpadden/eve-repro-nitro-wildcard-package-imports
- https://github.com/vercel/eve/pull/1181

## Regression testing

The new `test/unit/imports-wildcard` fixture imports `#internal/marker.js` and expects `dist/internal/marker.js` in the trace.

Before this change, both the cwd-based and root-based fixture variants failed because the marker file was absent. After the resolver change, both variants pass.

Validation performed:

- `pnpm build`
- `pnpm prettier-check`
- `pnpm exec jest test/unit.test.js --runInBand -t 'imports|exports-wildcard'`
- `pnpm exec jest --runInBand --silent` — 1,475 tests passed
