### PR TITLE
fix: warn when an asset is skipped at the package boundary

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -1299,15 +1299,18 @@ export default async function analyze(
         'node_modules' +
         path.sep;
       if (!assetPath.startsWith(nodeModulesBase)) {
-        if (job.log)
-          console.log(
-            'Skipping asset emission of ' +
-              assetPath +
-              ' for ' +
-              id +
-              ' as it is outside the package base ' +
-              pkgBase,
-          );
+        const message =
+          'Skipping asset emission of ' +
+          assetPath +
+          ' for ' +
+          id +
+          ' as it is outside the package base ' +
+          pkgBase;
+        // Also surfaced as a warning, not only under `job.log`: the file is otherwise
+        // simply absent from the output, so the first symptom is a runtime failure in
+        // the deployed application rather than anything visible at build time.
+        job.warnings.add(new Error(message));
+        if (job.log) console.log(message);
         return;
       }
     }

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -176,7 +176,7 @@ for (const { testName, isRoot } of unitTests) {
         // Ignore.
       }
 
-      const { fileList, reasons } = await nodeFileTrace(
+      const { fileList, reasons, warnings } = await nodeFileTrace(
         inputFileNames.map((file) => join(unitPath, file)),
         {
           conditions: testOpts.conditions,
@@ -215,6 +215,19 @@ for (const { testName, isRoot } of unitTests) {
         isRoot ? join('./', unitPath, f) : join('test/unit', testName, f);
 
       const getReasonType = (f) => reasons.get(normalizeInputRoot(f)).type;
+
+      // Only on the uncached pass: the second run replays cached analysis and does not
+      // re-emit warnings.
+      if (!cached && testName === 'pkg-cwd-asset-outside-pkg-base') {
+        // The asset stays out of the output, but the skip has to be reported: silently
+        // omitting a file the package reads at runtime only surfaces once the deployed
+        // application fails.
+        expect(
+          [...warnings].some((warning) =>
+            warning.message.startsWith('Skipping asset emission of'),
+          ),
+        ).toBe(true);
+      }
 
       if (testName === 'multi-input') {
         const collectFiles = (parent, files = new Set()) => {

--- a/test/unit/pkg-cwd-asset-outside-pkg-base/.gitignore
+++ b/test/unit/pkg-cwd-asset-outside-pkg-base/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/test/unit/pkg-cwd-asset-outside-pkg-base/input.js
+++ b/test/unit/pkg-cwd-asset-outside-pkg-base/input.js
@@ -1,0 +1,1 @@
+require('some-pkg');

--- a/test/unit/pkg-cwd-asset-outside-pkg-base/node_modules/some-pkg/index.js
+++ b/test/unit/pkg-cwd-asset-outside-pkg-base/node_modules/some-pkg/index.js
@@ -1,0 +1,13 @@
+const path = require('path');
+
+// Babel's CommonJS output for `await import(configPath)`, as shipped by packages that
+// look up a user config relative to the current working directory.
+const configPath = path.resolve('./some.config.js');
+
+module.exports = (function (specifier) {
+  return new Promise(function (r) {
+    return r(''.concat(specifier));
+  }).then(function (s) {
+    return require(s);
+  });
+})(configPath);

--- a/test/unit/pkg-cwd-asset-outside-pkg-base/node_modules/some-pkg/package.json
+++ b/test/unit/pkg-cwd-asset-outside-pkg-base/node_modules/some-pkg/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "some-pkg",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/test/unit/pkg-cwd-asset-outside-pkg-base/output.js
+++ b/test/unit/pkg-cwd-asset-outside-pkg-base/output.js
@@ -1,0 +1,6 @@
+[
+  "package.json",
+  "test/unit/pkg-cwd-asset-outside-pkg-base/input.js",
+  "test/unit/pkg-cwd-asset-outside-pkg-base/node_modules/some-pkg/index.js",
+  "test/unit/pkg-cwd-asset-outside-pkg-base/node_modules/some-pkg/package.json"
+]

--- a/test/unit/pkg-cwd-asset-outside-pkg-base/some.config.js
+++ b/test/unit/pkg-cwd-asset-outside-pkg-base/some.config.js
@@ -1,0 +1,1 @@
+module.exports = { config: true };


### PR DESCRIPTION
> [!NOTE]
> Used AI to investigate and propose this fix.  

Closes #606 (partially — see "What this does not change" below).

### Problem

The package-boundary guard added in #568 stops a package inside `node_modules` from emitting assets outside `node_modules`. The skip is currently only visible under `job.log`, so in a normal build the file is simply **absent from the output** and the first symptom is a runtime failure in the deployed application.

This cost us a multi-hour production outage. `next-i18next` resolves its user config from the current working directory:

```js
// next-i18next/dist/commonjs/serverSideTranslations.js
const configPath = path.resolve('./next-i18next.config.js');
if (!userConfig && fs.existsSync(configPath)) {
  userConfig = await import(configPath);
}
if (userConfig === null) {
  throw new Error(`next-i18next was unable to find a user config at ${configPath}`);
}
```

Babel compiles that dynamic `import()` into a Promise wrapper around `require`, which is analysed as an **asset** rather than a dependency, so the path flows through `emitAssetPath` and hits the guard. After Next.js 16.3.0 picked up a post-1.3.2 nft, the config stopped reaching the serverless bundle, `existsSync` returned false, and next-i18next threw **before any page rendered** — 500ing every server-rendered response, including the on-demand 404. `next build` exited 0 throughout, and there was nothing in the output to indicate why.

Looking up a config file from `process.cwd()` is a widespread convention, so this likely reaches beyond `next-i18next`.

### What this changes

The skip is added to `warnings` in addition to the existing `job.log` output, so consumers can surface it at build time.

```js
const message =
  'Skipping asset emission of ' + assetPath + ' for ' + id +
  ' as it is outside the package base ' + pkgBase;
job.warnings.add(new Error(message));
if (job.log) console.log(message);
```

### What this does not change

**Behaviour is identical** — the asset is still not emitted, and no existing expectation changes. I have deliberately not touched the boundary rule itself: the fixtures added in #568 assert it, so whether in-base assets *should* be skipped is a maintainer decision. That question is #606; this PR only makes the outcome observable either way.

### New test fixture

`test/unit/pkg-cwd-asset-outside-pkg-base` covers a case the existing `*-outside-base` fixtures do not. Those use `/../../secret.txt`, which normalises to `/secret.txt`; that path does not exist, so tracing returns at the stat check **before** reaching this guard — they pass without exercising it. Verified by instrumenting the branch: neither fixture reaches it.

The new fixture uses the Babel-transpiled dynamic import of a cwd-resolved path, which does reach the guard, and asserts:

- the asset is still absent from `fileList` (behaviour preserved)
- a warning is emitted

The assertion is scoped to the uncached pass, since the second run replays cached analysis and does not re-emit warnings.

### Verification

- `jest test/unit.test.js test/ecmascript.test.js`: **1375 passed** (1373 before, plus the two variants of the new fixture)
- `prettier --check` clean on all touched files
- Confirmed the new assertion is meaningful: reverting `src/analyze.ts` alone makes it fail
- Confirmed against the real-world case — tracing `next-i18next`'s `serverSideTranslations` entry now yields a warning naming `next-i18next.config.js`, where previously the file was dropped with no signal

`ecmascript.test.js` asserts `warnings.size === 0`, and it still passes, so no existing fixture triggers this path.