### PR TITLE
feat: complete wildcard imports resolution

### DIFF
--- a/src/resolve-dependency.ts
+++ b/src/resolve-dependency.ts
@@ -238,7 +238,7 @@ function addExportsTargetPath(
   if (typeof target !== 'string' || !target.startsWith('./')) return;
 
   const targetPath = wildcardReplacement
-    ? target.slice(1).replace(/\*/g, wildcardReplacement)
+    ? target.slice(1).replace(/\*/g, () => wildcardReplacement)
     : target.slice(1);
   const path = pkgPath + targetPath;
   if (!paths.includes(path)) {
@@ -355,7 +355,7 @@ async function resolveExportsImports(
       );
       if (typeof target === 'string' && target.startsWith('./')) {
         const resolvedPath =
-          pkgPath + target.slice(1).replace(/\*/g, wildcardReplacement);
+          pkgPath + target.slice(1).replace(/\*/g, () => wildcardReplacement);
         const paths = [resolvedPath];
 
         const exportsForSubpath = matchObj[match];
@@ -400,6 +400,15 @@ async function resolveExportsImports(
         }
 
         return await validateAndResolvePaths(paths, parent, job, cjsResolve);
+      } else if (isImports && typeof target === 'string') {
+        // The imports field additionally allows external dependencies as well
+        const resolved = await resolveDependency(
+          target.replace(/\*/g, () => wildcardReplacement),
+          parent,
+          job,
+          cjsResolve,
+        );
+        return Array.isArray(resolved) ? resolved : [resolved];
       }
     }
     if (!match.endsWith('/')) continue;

--- a/test/unit/imports-wildcard/dist/a$&b.js
+++ b/test/unit/imports-wildcard/dist/a$&b.js
@@ -1,0 +1,1 @@
+export const dollar = 'literal dollar replacement';

--- a/test/unit/imports-wildcard/dist/precedence.js
+++ b/test/unit/imports-wildcard/dist/precedence.js
@@ -1,0 +1,1 @@
+export const specific = 'specific wildcard pattern';

--- a/test/unit/imports-wildcard/generic/missing/thing.js.js
+++ b/test/unit/imports-wildcard/generic/missing/thing.js.js
@@ -1,0 +1,1 @@
+export const fallback = 'incorrect less-specific fallback';

--- a/test/unit/imports-wildcard/generic/precedence.js.js
+++ b/test/unit/imports-wildcard/generic/precedence.js.js
@@ -1,0 +1,1 @@
+export const specific = 'incorrect generic wildcard pattern';

--- a/test/unit/imports-wildcard/input.js
+++ b/test/unit/imports-wildcard/input.js
@@ -1,2 +1,7 @@
 import { marker } from '#internal/marker.js';
-console.log(marker);
+import { dollar } from '#a$&b.js';
+import { main } from '#lib/feature/index.js';
+import { specific } from '#precedence.js';
+import { external } from '#dep/thing.js';
+
+console.log(marker, dollar, main, specific, external);

--- a/test/unit/imports-wildcard/input.js
+++ b/test/unit/imports-wildcard/input.js
@@ -3,5 +3,8 @@ import { dollar } from '#a$&b.js';
 import { main } from '#lib/feature/index.js';
 import { specific } from '#precedence.js';
 import { external } from '#dep/thing.js';
+import { externalDollar } from '#dep/a$&b.js';
 
-console.log(marker, dollar, main, specific, external);
+import('#missing/thing.js').catch(() => {});
+
+console.log(marker, dollar, main, specific, external, externalDollar);

--- a/test/unit/imports-wildcard/node_modules/depper/a$&b.js
+++ b/test/unit/imports-wildcard/node_modules/depper/a$&b.js
@@ -1,0 +1,1 @@
+export const externalDollar = 'external literal dollar';

--- a/test/unit/imports-wildcard/node_modules/depper/package.json
+++ b/test/unit/imports-wildcard/node_modules/depper/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "depper",
+  "type": "module"
+}

--- a/test/unit/imports-wildcard/node_modules/depper/thing.js
+++ b/test/unit/imports-wildcard/node_modules/depper/thing.js
@@ -1,0 +1,1 @@
+export const external = 'external wildcard target';

--- a/test/unit/imports-wildcard/output.js
+++ b/test/unit/imports-wildcard/output.js
@@ -3,6 +3,7 @@
   "test/unit/imports-wildcard/dist/internal/marker.js",
   "test/unit/imports-wildcard/dist/precedence.js",
   "test/unit/imports-wildcard/input.js",
+  "test/unit/imports-wildcard/node_modules/depper/a$&b.js",
   "test/unit/imports-wildcard/node_modules/depper/package.json",
   "test/unit/imports-wildcard/node_modules/depper/thing.js",
   "test/unit/imports-wildcard/package.json",

--- a/test/unit/imports-wildcard/output.js
+++ b/test/unit/imports-wildcard/output.js
@@ -1,5 +1,10 @@
 [
+  "test/unit/imports-wildcard/dist/a$&b.js",
   "test/unit/imports-wildcard/dist/internal/marker.js",
+  "test/unit/imports-wildcard/dist/precedence.js",
   "test/unit/imports-wildcard/input.js",
-  "test/unit/imports-wildcard/package.json"
+  "test/unit/imports-wildcard/node_modules/depper/package.json",
+  "test/unit/imports-wildcard/node_modules/depper/thing.js",
+  "test/unit/imports-wildcard/package.json",
+  "test/unit/imports-wildcard/src/feature/main.js"
 ]

--- a/test/unit/imports-wildcard/package.json
+++ b/test/unit/imports-wildcard/package.json
@@ -5,6 +5,7 @@
     "#*": "./generic/*.js",
     "#*.js": "./dist/*.js",
     "#lib/*/index.js": "./src/*/main.js",
-    "#dep/*": "depper/*"
+    "#dep/*": "depper/*",
+    "#missing/*": "not-installed/*"
   }
 }

--- a/test/unit/imports-wildcard/package.json
+++ b/test/unit/imports-wildcard/package.json
@@ -2,6 +2,9 @@
   "name": "imports-wildcard",
   "type": "module",
   "imports": {
-    "#*.js": "./dist/*.js"
+    "#*": "./generic/*.js",
+    "#*.js": "./dist/*.js",
+    "#lib/*/index.js": "./src/*/main.js",
+    "#dep/*": "depper/*"
   }
 }

--- a/test/unit/imports-wildcard/src/feature/main.js
+++ b/test/unit/imports-wildcard/src/feature/main.js
@@ -1,0 +1,1 @@
+export const main = 'mid-path wildcard';

--- a/test/unit/module-sync-catchall/fallback/feature$&name.js
+++ b/test/unit/module-sync-catchall/fallback/feature$&name.js
@@ -1,0 +1,1 @@
+exports.dollar = 'fallback literal dollar replacement';

--- a/test/unit/module-sync-catchall/input.js
+++ b/test/unit/module-sync-catchall/input.js
@@ -1,2 +1,3 @@
 const { test } = require('test-pkg-sync-catchall/feature');
-console.log(test);
+const { dollar } = require('test-pkg-sync-catchall/feature$&name');
+console.log(test, dollar);

--- a/test/unit/module-sync-catchall/output.js
+++ b/test/unit/module-sync-catchall/output.js
@@ -1,6 +1,8 @@
 [
+  "test/unit/module-sync-catchall/fallback/feature$&name.js",
   "test/unit/module-sync-catchall/fallback/feature.js",
   "test/unit/module-sync-catchall/input.js",
   "test/unit/module-sync-catchall/package.json",
+  "test/unit/module-sync-catchall/sync/feature$&name.js",
   "test/unit/module-sync-catchall/sync/feature.js"
 ]

--- a/test/unit/module-sync-catchall/sync/feature$&name.js
+++ b/test/unit/module-sync-catchall/sync/feature$&name.js
@@ -1,0 +1,1 @@
+exports.dollar = 'module-sync literal dollar replacement';


### PR DESCRIPTION
## Summary

- preserve wildcard captures literally when substituting package `imports` and `exports` targets
- resolve wildcard `imports` targets that point to external packages
- stop at the selected wildcard key when its external target cannot resolve, matching Node instead of falling through to a less-specific pattern
- add regression coverage for dollar replacement sequences, mid-path patterns, pattern precedence, external targets, and module-sync catchall paths

## Context

Follow-up to #604 and the resolver conformance review in https://github.com/vercel/nft/pull/604#issuecomment-5330225804.

Three resolver gaps remained after wildcard trailers were added:

1. Passing a wildcard capture directly as the replacement string caused JavaScript replacement sequences such as `$&`, `$$`, ``$` ``, and `$'` to be interpreted instead of inserted literally.
2. Wildcard `imports` mappings only handled `./`-relative targets, even though Node also permits package targets such as `"#dep/*": "depper/*"`.
3. A matched wildcard key with an unresolved external target fell through to a less-specific key. Node selects one best match and reports the external resolution failure instead of retrying another pattern. Consumers relying on that accidental fallback may now receive a trace warning, matching Node's behavior.

This uses function replacers at all three target-substitution sites and mirrors the exact `imports` branch's external dependency resolution after wildcard substitution.

The `null` target fallthrough behavior noted in the review is intentionally not changed here because blocking a target can remove files from traces and warrants a separate compatibility decision. The existing `patternKeyCompare` implementation is also intentionally left unchanged; its comparator-consistency concern is informational and no incorrect wildcard selection has been demonstrated.

## Regression coverage

The fixtures now cover:

- a literal `$&` wildcard capture for package imports
- a literal `$&` capture in both module-sync and fallback export targets
- a literal `$&` capture in a wildcard import targeting an external package
- wildcard imports targeting an external package
- failure of a selected external target without fallthrough to an existing less-specific target
- a mid-path pattern (`#lib/*/index.js`)
- precedence of `#*.js` over `#*`, with both candidate files present

Mutation checks confirmed that the tests fail independently when each resolver fix is reverted, including the external-target function replacer and no-fallthrough behavior.

## Validation

- `pnpm build`
- `pnpm prettier-check`
- `git diff --check`
- `pnpm exec jest test/unit.test.js --runInBand --silent` — 304/304 passed locally on macOS (the platform skips two additional cwd/root cases compared with Linux)
- targeted wildcard tests — cwd and root variants passed
- direct Node execution of both modified fixtures
- CI matrix passed on the previous revision across Node 20, 22, 24, and 26 on Linux, macOS, and Windows; CI is rerunning for the added regression fixtures
