### PR TITLE
fix: do not glob from the filesystem root

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -1336,12 +1336,12 @@ export default async function analyze(
     if (assetPath.endsWith(path.sep + 'node_modules' + wildcardSuffix))
       return false;
     // do not emit directories above __dirname
-    if (
-      dir.startsWith(
-        assetPath.slice(0, assetPath.length - wildcardSuffix.length) + path.sep,
-      )
-    )
-      return false;
+    const wildcardIndex = assetPath.indexOf(WILDCARD);
+    const wildcardDir =
+      wildcardIndex === -1
+        ? assetPath.slice(0, assetPath.length - wildcardSuffix.length)
+        : assetPath.slice(0, assetPath.lastIndexOf(path.sep, wildcardIndex));
+    if (dir.startsWith(wildcardDir + path.sep)) return false;
     // do not emit asset directories higher than the node_modules base if a package
     if (pkgBase) {
       const nodeModulesBase =

--- a/test/unit/asset-wildcard-root/input.js
+++ b/test/unit/asset-wildcard-root/input.js
@@ -1,0 +1,3 @@
+const app_dir = process.env.APP_DIR;
+const route_id = process.env.ROUTE_ID;
+module.exports = `/${app_dir}/routes${route_id}`;

--- a/test/unit/asset-wildcard-root/output.js
+++ b/test/unit/asset-wildcard-root/output.js
@@ -1,0 +1,4 @@
+[
+  "package.json",
+  "test/unit/asset-wildcard-root/input.js"
+]

--- a/test/wildcard-root.test.js
+++ b/test/wildcard-root.test.js
@@ -1,0 +1,12 @@
+const { join, parse } = require('path');
+const { nodeFileTrace } = require('../out/node-file-trace');
+
+it('does not glob from the filesystem root', async () => {
+  const unitPath = join(__dirname, 'unit', 'asset-wildcard-root');
+  const input = join(unitPath, 'input.js');
+  const { fileList } = await nodeFileTrace([input], {
+    base: parse(input).root,
+    processCwd: unitPath,
+  });
+  expect([...fileList].some((file) => file.endsWith('input.js'))).toBe(true);
+});


### PR DESCRIPTION
A string like `` `/${dir}/routes` `` reaches `emitAssetPath` as `/<*>/routes`. On POSIX the parent is `''` and the stat fails. On Windows it resolves to `D:\<*>\routes`, the parent `D:` exists, and nft globs `D:/**/*/routes`, the entire drive.

The "do not emit directories above `__dirname`" rule in `validWildcard` only handled a trailing wildcard; it now checks the directory the wildcard sits in, which covers this and any other glob rooted at an ancestor of the importing file.

`test/wildcard-root.test.js` traces the fixture with `base` set to the filesystem root; the unit harness skips its `base: '/'` variant on Windows. Seen in the wild via sveltejs/kit#16963.
