### PR TITLE
fix: build node_modules paths with the platform separator

### DIFF
--- a/src/resolve-dependency.ts
+++ b/src/resolve-dependency.ts
@@ -112,6 +112,12 @@ export class NotFoundError extends Error {
 const nodeBuiltins = new Set<string>(builtinModules);
 const nodeSupportsModuleSync = getNodeMajorVersion() >= 22;
 
+// Specifiers always use '/', while filesystem paths must use the platform
+// separator, or path comparisons against sep-joined prefixes fail on Windows.
+function toPath(specifier: string) {
+  return sep === '/' ? specifier : specifier.replace(/\//g, sep);
+}
+
 function getPkgName(name: string) {
   const segments = name.split('/');
   if (name[0] === '@' && segments.length > 1)
@@ -240,7 +246,7 @@ function addExportsTargetPath(
   const targetPath = wildcardReplacement
     ? target.slice(1).replace(/\*/g, wildcardReplacement)
     : target.slice(1);
-  const path = pkgPath + targetPath;
+  const path = pkgPath + toPath(targetPath);
   if (!paths.includes(path)) {
     paths.push(path);
   }
@@ -303,7 +309,7 @@ async function resolveExportsImports(
       nodeSupportsModuleSync,
     );
     if (typeof target === 'string' && target.startsWith('./')) {
-      const resolvedPath = pkgPath + target.slice(1);
+      const resolvedPath = pkgPath + toPath(target.slice(1));
       const paths = [resolvedPath];
 
       const exportsForSubpath = matchObj[subpath];
@@ -355,7 +361,7 @@ async function resolveExportsImports(
       );
       if (typeof target === 'string' && target.startsWith('./')) {
         const resolvedPath =
-          pkgPath + target.slice(1).replace(/\*/g, wildcardReplacement);
+          pkgPath + toPath(target.slice(1).replace(/\*/g, wildcardReplacement));
         const paths = [resolvedPath];
 
         const exportsForSubpath = matchObj[match];
@@ -416,7 +422,7 @@ async function resolveExportsImports(
         target.startsWith('./')
       ) {
         const resolvedPath =
-          pkgPath + target.slice(1) + subpath.slice(match.length);
+          pkgPath + toPath(target.slice(1) + subpath.slice(match.length));
         return await validateAndResolvePaths(
           [resolvedPath],
           parent,
@@ -512,6 +518,8 @@ async function resolvePackage(
   if (name.startsWith('node:')) return name;
 
   const pkgName = getPkgName(name) || '';
+  const pkgNamePath = toPath(pkgName);
+  const namePath = toPath(name);
 
   // package own name resolution
   let selfResolved: string | string[] | undefined;
@@ -555,12 +563,12 @@ async function resolvePackage(
     const nodeModulesDir = packageParent + sep + 'node_modules';
     const stat = await job.stat(nodeModulesDir);
     if (!stat || !stat.isDirectory()) continue;
-    const pkgCfg = await getPkgCfg(nodeModulesDir + sep + pkgName, job);
+    const pkgCfg = await getPkgCfg(nodeModulesDir + sep + pkgNamePath, job);
     const { exports: pkgExports } = pkgCfg || {};
 
     if (pkgCfg) {
       await resolveRemappings(
-        nodeModulesDir + sep + pkgName,
+        nodeModulesDir + sep + pkgNamePath,
         pkgCfg,
         parent,
         job,
@@ -576,10 +584,10 @@ async function resolvePackage(
       let legacyResolved;
       if (!job.exportsOnly)
         legacyResolved =
-          (await resolveFile(nodeModulesDir + sep + name, parent, job)) ||
-          (await resolveDir(nodeModulesDir + sep + name, parent, job));
+          (await resolveFile(nodeModulesDir + sep + namePath, parent, job)) ||
+          (await resolveDir(nodeModulesDir + sep + namePath, parent, job));
       const resolved = await resolveExportsImports(
-        nodeModulesDir + sep + pkgName,
+        nodeModulesDir + sep + pkgNamePath,
         pkgExports,
         '.' + name.slice(pkgName.length),
         job,
@@ -589,7 +597,7 @@ async function resolvePackage(
       );
       if (resolved) {
         await job.emitFile(
-          nodeModulesDir + sep + pkgName + sep + 'package.json',
+          nodeModulesDir + sep + pkgNamePath + sep + 'package.json',
           'resolve',
           parent,
         );
@@ -600,8 +608,8 @@ async function resolvePackage(
       if (legacyResolved) return legacyResolved;
     } else {
       const resolved =
-        (await resolveFile(nodeModulesDir + sep + name, parent, job)) ||
-        (await resolveDir(nodeModulesDir + sep + name, parent, job));
+        (await resolveFile(nodeModulesDir + sep + namePath, parent, job)) ||
+        (await resolveDir(nodeModulesDir + sep + namePath, parent, job));
       if (resolved) {
         if (selfResolved) {
           if (Array.isArray(selfResolved)) {

--- a/test/scoped-symlink.test.js
+++ b/test/scoped-symlink.test.js
@@ -1,0 +1,78 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { nodeFileTrace } = require('../out/node-file-trace');
+
+// The symlinks are created at runtime rather than committed as fixtures,
+// because a Windows checkout does not necessarily materialize them.
+async function setupWorkspace() {
+  const base = await fs.promises.mkdtemp(
+    path.join(await fs.promises.realpath(os.tmpdir()), 'nft-scoped-'),
+  );
+
+  for (const [dir, name] of [
+    ['scoped-pkg', '@scope/pkg'],
+    ['unscoped-pkg', 'unscoped'],
+  ]) {
+    await fs.promises.mkdir(path.join(base, dir, 'dist'), { recursive: true });
+    await fs.promises.writeFile(
+      path.join(base, dir, 'package.json'),
+      JSON.stringify({
+        name,
+        type: 'module',
+        exports: { './*': './dist/*.js' },
+      }),
+    );
+    await fs.promises.writeFile(
+      path.join(base, dir, 'dist', 'sub.js'),
+      'export const value = 1;\n',
+    );
+  }
+
+  await fs.promises.mkdir(path.join(base, 'node_modules', '@scope'), {
+    recursive: true,
+  });
+  // 'junction' so that no elevated privileges are needed on Windows.
+  await fs.promises.symlink(
+    path.join(base, 'scoped-pkg'),
+    path.join(base, 'node_modules', '@scope', 'pkg'),
+    'junction',
+  );
+  await fs.promises.symlink(
+    path.join(base, 'unscoped-pkg'),
+    path.join(base, 'node_modules', 'unscoped'),
+    'junction',
+  );
+
+  await fs.promises.writeFile(
+    path.join(base, 'input.mjs'),
+    "import '@scope/pkg/sub';\nimport 'unscoped/sub';\n",
+  );
+
+  return base;
+}
+
+describe('symlinked packages in node_modules', () => {
+  let base;
+
+  beforeAll(async () => {
+    base = await setupWorkspace();
+  });
+
+  afterAll(async () => {
+    if (base) await fs.promises.rm(base, { recursive: true, force: true });
+  });
+
+  it('emits the symlink for scoped and unscoped packages', async () => {
+    const { fileList } = await nodeFileTrace([path.join(base, 'input.mjs')], {
+      base,
+      processCwd: base,
+    });
+    const files = [...fileList].map((file) => file.split(path.sep).join('/'));
+
+    expect(files).toContain('node_modules/@scope/pkg');
+    expect(files).toContain('node_modules/unscoped');
+    expect(files).toContain('scoped-pkg/dist/sub.js');
+    expect(files).toContain('unscoped-pkg/dist/sub.js');
+  });
+});


### PR DESCRIPTION
Package specifiers always use `/`, so concatenating a scoped name or an `exports` target into a path yields `…\node_modules\@scope/pkg` on Windows. Comparisons against a sep-joined prefix — `inPath()` while walking symlinks — then fail, and the `node_modules` symlink of a scoped package is never emitted, leaving a standalone deployment without it.

Only CommonJS was unaffected, because `resolveDir()` happens to pass its paths through `resolve()`; the ESM branch of `validateAndResolvePaths()` keeps them verbatim. Translate separators where a specifier becomes a path instead.

<!--
PRs prefixed with `chore:` will skip creating a changelog entry and release.
PRs prefixed with `fix:` will do a patch release.
PRs prefixed with `feat:` will do a minor release.
-->
