### PR TITLE
fix: revert packageBase constraint of asset emission

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -1291,26 +1291,6 @@ export default async function analyze(
       return;
     }
     if (wildcardIndex !== -1 && stats.isFile()) return;
-    // do not emit assets outside the package boundary if inside node_modules
-    if (pkgBase) {
-      const nodeModulesBase =
-        id.substring(0, id.indexOf(path.sep + 'node_modules')) +
-        path.sep +
-        'node_modules' +
-        path.sep;
-      if (!assetPath.startsWith(nodeModulesBase)) {
-        if (job.log)
-          console.log(
-            'Skipping asset emission of ' +
-              assetPath +
-              ' for ' +
-              id +
-              ' as it is outside the package base ' +
-              pkgBase,
-          );
-        return;
-      }
-    }
     if (stats.isFile()) {
       // do not emit file assets outside job.base
       if (job.ignoreFn(path.relative(job.base, assetPath))) return;

--- a/test/unit/env-file-from-pkg/.env
+++ b/test/unit/env-file-from-pkg/.env
@@ -1,0 +1,1 @@
+MY_SECRET=value

--- a/test/unit/env-file-from-pkg/.gitignore
+++ b/test/unit/env-file-from-pkg/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/test/unit/env-file-from-pkg/input.js
+++ b/test/unit/env-file-from-pkg/input.js
@@ -1,0 +1,1 @@
+require('some-pkg');

--- a/test/unit/env-file-from-pkg/node_modules/some-pkg/index.js
+++ b/test/unit/env-file-from-pkg/node_modules/some-pkg/index.js
@@ -1,0 +1,4 @@
+const fs = require('fs');
+const path = require('path');
+
+fs.readFileSync(path.resolve(process.cwd(), '.env'));

--- a/test/unit/env-file-from-pkg/node_modules/some-pkg/package.json
+++ b/test/unit/env-file-from-pkg/node_modules/some-pkg/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "some-pkg",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/test/unit/env-file-from-pkg/output.js
+++ b/test/unit/env-file-from-pkg/output.js
@@ -1,0 +1,7 @@
+[
+  "package.json",
+  "test/unit/env-file-from-pkg/.env",
+  "test/unit/env-file-from-pkg/input.js",
+  "test/unit/env-file-from-pkg/node_modules/some-pkg/index.js",
+  "test/unit/env-file-from-pkg/node_modules/some-pkg/package.json"
+]


### PR DESCRIPTION
Reverts half of #568.

Closes #607.

Fixes #606.

Basically, #568 does two things while stating it does one:

1. Ignore any paths outside the job's root
2. Ignore any paths emitted by a `node_modules` file which sit outside that same `node_modules`

These were both introduced to fix some problems with sveltekit including things like `/bin` and what not. However, only the first is needed for that.

The second change seems unnecessary and breaks a lot of common patterns (e.g. the `dotenv` one in the newly added test).

<!--
PRs prefixed with `chore:` will skip creating a changelog entry and release.
PRs prefixed with `fix:` will do a patch release.
PRs prefixed with `feat:` will do a minor release.
-->
